### PR TITLE
listing deals from local db and metadata from web3storage

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
           components: rustfmt
 
@@ -43,7 +43,7 @@ jobs:
        uses: actions-rs/toolchain@v1
        with:
          profile: minimal
-         toolchain: nightly
+         toolchain: stable
          override: true
 
      - name: Install tomlfmt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
           components: clippy
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         os:
           - ubuntu-latest
         toolchain:
-          - nightly
+          - stable
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,16 +843,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3354,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -3364,14 +3354,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
 ]
@@ -135,6 +135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d305ee29f6979729d0a2c95abba14cd6b466e161287ba54583aaff69424f6e0f"
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "array-bytes"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +168,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
  "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
 ]
 
 [[package]]
@@ -274,6 +301,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,9 +401,12 @@ dependencies = [
  "hex",
  "jemallocator",
  "log",
+ "multibase",
  "once_cell",
  "openssl",
+ "reqwest",
  "secp256k1",
+ "serde",
  "serde_json",
  "sqlx",
  "stderrlog",
@@ -379,6 +415,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "warp",
+ "wiremock",
 ]
 
 [[package]]
@@ -675,7 +712,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2 0.12.2",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "thiserror",
 ]
@@ -705,6 +742,15 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-hex"
@@ -872,7 +918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -901,6 +947,45 @@ name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c904b33cc60130e1aeea4956ab803d08a3f4a0ca82d64ed757afac3891f2bb99"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fdf3fce3ce863539ec1d7fd1b6dcc3c645663376b43ed376bbf887733e4f772"
+dependencies = [
+ "data-encoding",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
 
 [[package]]
 name = "der"
@@ -1052,7 +1137,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8 0.10.2",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1093,7 +1178,7 @@ dependencies = [
  "hex",
  "k256",
  "log",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "serde-hex",
@@ -1151,7 +1236,7 @@ dependencies = [
  "hex",
  "hmac",
  "pbkdf2 0.11.0",
- "rand",
+ "rand 0.8.5",
  "scrypt",
  "serde",
  "serde_json",
@@ -1308,7 +1393,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "open-fastrlp",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "serde_json",
@@ -1408,7 +1493,7 @@ dependencies = [
  "elliptic-curve",
  "eth-keystore",
  "ethers-core",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "thiserror",
  "tracing",
@@ -1482,7 +1567,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1493,7 +1578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1632,6 +1717,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-locks"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,13 +1814,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1888,7 +1999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2038,6 +2149,27 @@ dependencies = [
  "bytes",
  "http",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64 0.13.1",
+ "futures-lite",
+ "http",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
 ]
 
 [[package]]
@@ -2199,6 +2331,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
 ]
+
+[[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "inout"
@@ -2484,7 +2622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -2504,6 +2642,17 @@ dependencies = [
  "mime",
  "spin 0.9.8",
  "version_check",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+dependencies = [
+ "base-x",
+ "data-encoding",
+ "data-encoding-macro",
 ]
 
 [[package]]
@@ -2569,7 +2718,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec 1.11.0",
  "zeroize",
 ]
@@ -2780,6 +2929,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,7 +2964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2917,7 +3072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3128,13 +3283,36 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3144,7 +3322,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -3153,7 +3340,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3211,7 +3407,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "redox_syscall 0.2.16",
  "thiserror",
 ]
@@ -3291,6 +3487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3360,7 +3562,7 @@ dependencies = [
  "num-traits",
  "pkcs1 0.3.3",
  "pkcs8 0.8.0",
- "rand_core",
+ "rand_core 0.6.4",
  "smallvec 1.11.0",
  "subtle",
  "zeroize",
@@ -3381,7 +3583,7 @@ dependencies = [
  "num-traits",
  "pkcs1 0.7.5",
  "pkcs8 0.10.2",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki 0.7.2",
  "subtle",
@@ -3679,6 +3881,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3747,7 +3960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3996,7 +4209,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa 0.9.2",
  "serde",
  "sha1",
@@ -4036,7 +4249,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha1",
@@ -4553,7 +4766,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror",
  "url",
@@ -4572,7 +4785,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "rustls",
  "sha1",
  "thiserror",
@@ -4661,6 +4874,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4687,7 +4901,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "serde",
 ]
 
@@ -4697,7 +4911,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -4711,6 +4925,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"
@@ -4761,6 +4981,12 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -5001,6 +5227,28 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f71803d3a1c80377a06221e0530be02035d5b3e854af56c6ece7ac20ac441d"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.21.4",
+ "deadpool",
+ "futures",
+ "futures-timer",
+ "http-types",
+ "hyper",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ openssl = { version = "0.10.57", features = ["vendored"] }
 secp256k1 = { version = "0.27.0", features = ["recovery"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
-sqlx = { version = "0.7.1", features = ["postgres", "runtime-tokio-native-tls"] }
+sqlx = { version = "0.7.1", features = ["postgres", "runtime-tokio-native-tls", "chrono"] }
 stderrlog = "0.5.4"
 thiserror = "1.0.48"
 tiny-keccak = "2.0.2"

--- a/lib/evm/src/contract.rs
+++ b/lib/evm/src/contract.rs
@@ -1568,54 +1568,50 @@ pub mod basin_storage {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded) = <::std::string::String as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <::std::string::String as ::ethers::core::abi::AbiDecode>::decode(
+                    data,
+                ) {
                 return Ok(Self::RevertString(decoded));
             }
-            if let Ok(decoded) = <ActorError as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <ActorError as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::ActorError(decoded));
             }
-            if let Ok(decoded) = <ActorNotFound as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <ActorNotFound as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::ActorNotFound(decoded));
             }
-            if let Ok(decoded) = <DealEpochAlreadyExists as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <DealEpochAlreadyExists as ::ethers::core::abi::AbiDecode>::decode(
+                    data,
+                ) {
                 return Ok(Self::DealEpochAlreadyExists(decoded));
             }
-            if let Ok(decoded) = <FailToCallActor as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <FailToCallActor as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::FailToCallActor(decoded));
             }
-            if let Ok(decoded) = <InvalidCodec as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <InvalidCodec as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::InvalidCodec(decoded));
             }
-            if let Ok(decoded) = <InvalidResponseLength as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <InvalidResponseLength as ::ethers::core::abi::AbiDecode>::decode(
+                    data,
+                ) {
                 return Ok(Self::InvalidResponseLength(decoded));
             }
-            if let Ok(decoded) = <NotEnoughBalance as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <NotEnoughBalance as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::NotEnoughBalance(decoded));
             }
-            if let Ok(decoded) = <PubAlreadyExists as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <PubAlreadyExists as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::PubAlreadyExists(decoded));
             }
-            if let Ok(decoded) = <PubDoesNotExist as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <PubDoesNotExist as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::PubDoesNotExist(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -2297,114 +2293,100 @@ pub mod basin_storage {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded) = <DefaultAdminRoleCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <DefaultAdminRoleCall as ::ethers::core::abi::AbiDecode>::decode(
+                    data,
+                ) {
                 return Ok(Self::DefaultAdminRole(decoded));
             }
-            if let Ok(decoded) = <PubAdminRoleCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <PubAdminRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::PubAdminRole(decoded));
             }
-            if let Ok(decoded) = <AddDealsCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <AddDealsCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::AddDeals(decoded));
             }
-            if let Ok(decoded) = <CreatePubCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <CreatePubCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::CreatePub(decoded));
             }
-            if let Ok(decoded) = <DealActivationCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <DealActivationCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DealActivation(decoded));
             }
-            if let Ok(decoded) = <DealClientCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <DealClientCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DealClient(decoded));
             }
-            if let Ok(decoded) = <DealClientCollateralCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <DealClientCollateralCall as ::ethers::core::abi::AbiDecode>::decode(
+                    data,
+                ) {
                 return Ok(Self::DealClientCollateral(decoded));
             }
-            if let Ok(decoded) = <DealLabelCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <DealLabelCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DealLabel(decoded));
             }
-            if let Ok(decoded) = <DealProviderCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <DealProviderCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DealProvider(decoded));
             }
-            if let Ok(decoded) = <DealProviderCollateralCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <DealProviderCollateralCall as ::ethers::core::abi::AbiDecode>::decode(
+                    data,
+                ) {
                 return Ok(Self::DealProviderCollateral(decoded));
             }
-            if let Ok(decoded) = <DealTermCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <DealTermCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DealTerm(decoded));
             }
-            if let Ok(decoded) = <DealTotalPriceCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <DealTotalPriceCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DealTotalPrice(decoded));
             }
-            if let Ok(decoded) = <DealVerifiedCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <DealVerifiedCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DealVerified(decoded));
             }
-            if let Ok(decoded) = <GetRoleAdminCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <GetRoleAdminCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::GetRoleAdmin(decoded));
             }
-            if let Ok(decoded) = <GrantRoleCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <GrantRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::GrantRole(decoded));
             }
-            if let Ok(decoded) = <HasRoleCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <HasRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::HasRole(decoded));
             }
-            if let Ok(decoded) = <LatestNDealsCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <LatestNDealsCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::LatestNDeals(decoded));
             }
-            if let Ok(decoded) = <PaginatedDealsCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <PaginatedDealsCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::PaginatedDeals(decoded));
             }
-            if let Ok(decoded) = <PubsOfOwnerCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <PubsOfOwnerCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::PubsOfOwner(decoded));
             }
-            if let Ok(decoded) = <RenounceRoleCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <RenounceRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::RenounceRole(decoded));
             }
-            if let Ok(decoded) = <RevokeRoleCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <RevokeRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::RevokeRole(decoded));
             }
-            if let Ok(decoded) = <SupportsInterfaceCall as ::ethers::core::abi::AbiDecode>::decode(
-                data,
-            ) {
+            if let Ok(decoded)
+                = <SupportsInterfaceCall as ::ethers::core::abi::AbiDecode>::decode(
+                    data,
+                ) {
                 return Ok(Self::SupportsInterface(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())

--- a/lib/evm/src/contract.rs
+++ b/lib/evm/src/contract.rs
@@ -7,7 +7,7 @@ pub use basin_storage::*;
     clippy::upper_case_acronyms,
     clippy::type_complexity,
     dead_code,
-    non_camel_case_types,
+    non_camel_case_types
 )]
 pub mod basin_storage {
     #[allow(deprecated)]
@@ -19,1028 +19,822 @@ pub mod basin_storage {
             functions: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("DEFAULT_ADMIN_ROLE"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("DEFAULT_ADMIN_ROLE"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes32"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("DEFAULT_ADMIN_ROLE"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bytes32"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("PUB_ADMIN_ROLE"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("PUB_ADMIN_ROLE"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes32"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("PUB_ADMIN_ROLE"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bytes32"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("addDeals"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("addDeals"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("pub"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("string"),
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("addDeals"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("pub"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::String,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("string"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("deals"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Array(
+                                    ::std::boxed::Box::new(
+                                        ::ethers::core::abi::ethabi::ParamType::Tuple(::std::vec![
+                                            ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                                            ::ethers::core::abi::ethabi::ParamType::String,
+                                            ::ethers::core::abi::ethabi::ParamType::String,
+                                        ],),
                                     ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("deals"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Array(
-                                        ::std::boxed::Box::new(
-                                            ::ethers::core::abi::ethabi::ParamType::Tuple(
-                                                ::std::vec![
-                                                    ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                                    ::ethers::core::abi::ethabi::ParamType::String,
-                                                    ::ethers::core::abi::ethabi::ParamType::String,
-                                                ],
-                                            ),
-                                        ),
+                                ),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned(
+                                        "struct BasinStorage.DealInfo[]",
                                     ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned(
-                                            "struct BasinStorage.DealInfo[]",
-                                        ),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("createPub"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("createPub"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("owner"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("pub"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("string"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("createPub"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("owner"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("pub"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::String,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("string"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("dealActivation"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("dealActivation"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("dealID"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int64"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int64"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("dealActivation"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("dealID"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
+                            ),
+                        },],
+                        outputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::string::String::new(),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Int(64usize),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("int64"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::string::String::new(),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Int(64usize),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("int64"),
+                                ),
+                            },
+                        ],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("dealClient"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("dealClient"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("dealID"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("dealClient"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("dealID"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("dealClientCollateral"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned(
-                                "dealClientCollateral",
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("dealClientCollateral",),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("dealID"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
                             ),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("dealID"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Tuple(
-                                        ::std::vec![
-                                            ::ethers::core::abi::ethabi::ParamType::Bytes,
-                                            ::ethers::core::abi::ethabi::ParamType::Bool,
-                                        ],
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned(
-                                            "struct CommonTypes.BigInt",
-                                        ),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Tuple(::std::vec![
+                                ::ethers::core::abi::ethabi::ParamType::Bytes,
+                                ::ethers::core::abi::ethabi::ParamType::Bool,
+                            ],),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("struct CommonTypes.BigInt",),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("dealLabel"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("dealLabel"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("dealID"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Bytes,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bool"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("dealLabel"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("dealID"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
+                            ),
+                        },],
+                        outputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::string::String::new(),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Bytes,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("bytes"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::string::String::new(),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("bool"),
+                                ),
+                            },
+                        ],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("dealProvider"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("dealProvider"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("dealID"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("dealProvider"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("dealID"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("dealProviderCollateral"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned(
-                                "dealProviderCollateral",
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("dealProviderCollateral",),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("dealID"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
                             ),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("dealID"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Tuple(
-                                        ::std::vec![
-                                            ::ethers::core::abi::ethabi::ParamType::Bytes,
-                                            ::ethers::core::abi::ethabi::ParamType::Bool,
-                                        ],
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned(
-                                            "struct CommonTypes.BigInt",
-                                        ),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Tuple(::std::vec![
+                                ::ethers::core::abi::ethabi::ParamType::Bytes,
+                                ::ethers::core::abi::ethabi::ParamType::Bool,
+                            ],),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("struct CommonTypes.BigInt",),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("dealTerm"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("dealTerm"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("dealID"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int64"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int64"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("dealTerm"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("dealID"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
+                            ),
+                        },],
+                        outputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::string::String::new(),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Int(64usize),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("int64"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::string::String::new(),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Int(64usize),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("int64"),
+                                ),
+                            },
+                        ],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("dealTotalPrice"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("dealTotalPrice"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("dealID"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Tuple(
-                                        ::std::vec![
-                                            ::ethers::core::abi::ethabi::ParamType::Bytes,
-                                            ::ethers::core::abi::ethabi::ParamType::Bool,
-                                        ],
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned(
-                                            "struct CommonTypes.BigInt",
-                                        ),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("dealTotalPrice"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("dealID"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Tuple(::std::vec![
+                                ::ethers::core::abi::ethabi::ParamType::Bytes,
+                                ::ethers::core::abi::ethabi::ParamType::Bool,
+                            ],),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("struct CommonTypes.BigInt",),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("dealVerified"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("dealVerified"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("dealID"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bool"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("dealVerified"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("dealID"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bool"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("getRoleAdmin"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("getRoleAdmin"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("role"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes32"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes32"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("getRoleAdmin"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("role"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bytes32"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bytes32"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("grantRole"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("grantRole"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("role"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes32"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("account"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("grantRole"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("role"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("bytes32"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("account"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("hasRole"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("hasRole"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("role"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes32"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("account"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bool"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("hasRole"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("role"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("bytes32"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("account"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bool"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("latestNDeals"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("latestNDeals"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("pub"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("string"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("n"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Array(
-                                        ::std::boxed::Box::new(
-                                            ::ethers::core::abi::ethabi::ParamType::Tuple(
-                                                ::std::vec![
-                                                    ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                                    ::ethers::core::abi::ethabi::ParamType::String,
-                                                    ::ethers::core::abi::ethabi::ParamType::String,
-                                                ],
-                                            ),
-                                        ),
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned(
-                                            "struct BasinStorage.DealInfo[]",
-                                        ),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("latestNDeals"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("pub"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::String,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("string"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("n"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Array(
+                                ::std::boxed::Box::new(
+                                    ::ethers::core::abi::ethabi::ParamType::Tuple(::std::vec![
+                                        ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                                        ::ethers::core::abi::ethabi::ParamType::String,
+                                        ::ethers::core::abi::ethabi::ParamType::String,
+                                    ],),
+                                ),
+                            ),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("struct BasinStorage.DealInfo[]",),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("paginatedDeals"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("paginatedDeals"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("pub"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("string"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("offset"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("limit"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Array(
-                                        ::std::boxed::Box::new(
-                                            ::ethers::core::abi::ethabi::ParamType::Tuple(
-                                                ::std::vec![
-                                                    ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                                    ::ethers::core::abi::ethabi::ParamType::String,
-                                                    ::ethers::core::abi::ethabi::ParamType::String,
-                                                ],
-                                            ),
-                                        ),
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned(
-                                            "struct BasinStorage.DealInfo[]",
-                                        ),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("paginatedDeals"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("pub"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::String,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("string"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("offset"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("limit"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Array(
+                                ::std::boxed::Box::new(
+                                    ::ethers::core::abi::ethabi::ParamType::Tuple(::std::vec![
+                                        ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                                        ::ethers::core::abi::ethabi::ParamType::String,
+                                        ::ethers::core::abi::ethabi::ParamType::String,
+                                    ],),
+                                ),
+                            ),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("struct BasinStorage.DealInfo[]",),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("pubsOfOwner"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("pubsOfOwner"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("owner"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Array(
-                                        ::std::boxed::Box::new(
-                                            ::ethers::core::abi::ethabi::ParamType::String,
-                                        ),
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("string[]"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("pubsOfOwner"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("owner"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Array(
+                                ::std::boxed::Box::new(
+                                    ::ethers::core::abi::ethabi::ParamType::String,
+                                ),
+                            ),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("string[]"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("renounceRole"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("renounceRole"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("role"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes32"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("account"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("renounceRole"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("role"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("bytes32"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("account"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("revokeRole"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("revokeRole"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("role"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes32"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("account"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("address"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("revokeRole"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("role"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("bytes32"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("account"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("address"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("supportsInterface"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("supportsInterface"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("interfaceId"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        4usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bytes4"),
-                                    ),
-                                },
-                            ],
-                            outputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Bool,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("bool"),
-                                    ),
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("supportsInterface"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("interfaceId"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(4usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bytes4"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Bool,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("bool"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
                 ),
             ]),
             events: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("DealAdded"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("DealAdded"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("dealId"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("pub"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("owner"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("cid"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
-                                    indexed: false,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Event {
+                        name: ::std::borrow::ToOwned::to_owned("DealAdded"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("dealId"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("pub"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::String,
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("owner"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("cid"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::String,
+                                indexed: false,
+                            },
+                        ],
+                        anonymous: false,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("PubCreated"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("PubCreated"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("pub"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("owner"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: true,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Event {
+                        name: ::std::borrow::ToOwned::to_owned("PubCreated"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("pub"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::String,
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("owner"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: true,
+                            },
+                        ],
+                        anonymous: false,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("RoleAdminChanged"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("RoleAdminChanged"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("role"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("previousAdminRole"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("newAdminRole"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: true,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Event {
+                        name: ::std::borrow::ToOwned::to_owned("RoleAdminChanged"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("role"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("previousAdminRole"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("newAdminRole"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                                indexed: true,
+                            },
+                        ],
+                        anonymous: false,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("RoleGranted"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("RoleGranted"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("role"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("account"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("sender"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: true,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Event {
+                        name: ::std::borrow::ToOwned::to_owned("RoleGranted"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("role"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("account"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("sender"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: true,
+                            },
+                        ],
+                        anonymous: false,
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("RoleRevoked"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("RoleRevoked"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("role"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("account"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("sender"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Address,
-                                    indexed: true,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::Event {
+                        name: ::std::borrow::ToOwned::to_owned("RoleRevoked"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("role"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(32usize,),
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("account"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: true,
+                            },
+                            ::ethers::core::abi::ethabi::EventParam {
+                                name: ::std::borrow::ToOwned::to_owned("sender"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                                indexed: true,
+                            },
+                        ],
+                        anonymous: false,
+                    },],
                 ),
             ]),
             errors: ::core::convert::From::from([
                 (
                     ::std::borrow::ToOwned::to_owned("ActorError"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("ActorError"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("errorCode"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("int256"),
-                                    ),
-                                },
-                            ],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("ActorError"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("errorCode"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Int(256usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("int256"),
+                            ),
+                        },],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("ActorNotFound"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("ActorNotFound"),
-                            inputs: ::std::vec![],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("ActorNotFound"),
+                        inputs: ::std::vec![],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("DealEpochAlreadyExists"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned(
-                                "DealEpochAlreadyExists",
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("DealEpochAlreadyExists",),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("epoch"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
                             ),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("epoch"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                        },
-                    ],
+                        },],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("FailToCallActor"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("FailToCallActor"),
-                            inputs: ::std::vec![],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("FailToCallActor"),
+                        inputs: ::std::vec![],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("InvalidCodec"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("InvalidCodec"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint64"),
-                                    ),
-                                },
-                            ],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("InvalidCodec"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(64usize),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint64"),
+                            ),
+                        },],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("InvalidResponseLength"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned(
-                                "InvalidResponseLength",
-                            ),
-                            inputs: ::std::vec![],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("InvalidResponseLength",),
+                        inputs: ::std::vec![],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("NotEnoughBalance"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("NotEnoughBalance"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("balance"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("value"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::Uint(
-                                        256usize,
-                                    ),
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("uint256"),
-                                    ),
-                                },
-                            ],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("NotEnoughBalance"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("balance"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("value"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("PubAlreadyExists"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("PubAlreadyExists"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("reason"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("string"),
-                                    ),
-                                },
-                            ],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("PubAlreadyExists"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("reason"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::String,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("string"),
+                            ),
+                        },],
+                    },],
                 ),
                 (
                     ::std::borrow::ToOwned::to_owned("PubDoesNotExist"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::AbiError {
-                            name: ::std::borrow::ToOwned::to_owned("PubDoesNotExist"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::Param {
-                                    name: ::std::borrow::ToOwned::to_owned("reason"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::String,
-                                    internal_type: ::core::option::Option::Some(
-                                        ::std::borrow::ToOwned::to_owned("string"),
-                                    ),
-                                },
-                            ],
-                        },
-                    ],
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("PubDoesNotExist"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("reason"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::String,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("string"),
+                            ),
+                        },],
+                    },],
                 ),
             ]),
             receive: false,
@@ -1048,21 +842,18 @@ pub mod basin_storage {
         }
     }
     ///The parsed JSON ABI of the contract.
-    pub static BASINSTORAGE_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> = ::ethers::contract::Lazy::new(
-        __abi,
-    );
+    pub static BASINSTORAGE_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> =
+        ::ethers::contract::Lazy::new(__abi);
     #[rustfmt::skip]
     const __BYTECODE: &[u8] = b"`\x80`@R4\x80\x15b\0\0\x11W`\0\x80\xFD[Pb\0\0\x1F`\x003b\0\0%V[b\0\0\xC6V[`\0\x82\x81R` \x81\x81R`@\x80\x83 `\x01`\x01`\xA0\x1B\x03\x85\x16\x84R\x90\x91R\x90 T`\xFF\x16b\0\0\xC2W`\0\x82\x81R` \x81\x81R`@\x80\x83 `\x01`\x01`\xA0\x1B\x03\x85\x16\x84R\x90\x91R\x90 \x80T`\xFF\x19\x16`\x01\x17\x90Ub\0\0\x813\x90V[`\x01`\x01`\xA0\x1B\x03\x16\x81`\x01`\x01`\xA0\x1B\x03\x16\x83\x7F/\x87\x88\x11~~\xFF\x1D\x82\xE9&\xECyI\x01\xD1|x\x02JP'\t@0E@\xA73eo\r`@Q`@Q\x80\x91\x03\x90\xA4[PPV[a/s\x80b\0\0\xD6`\09`\0\xF3\xFE`\x80`@R4\x80\x15a\0\x10W`\0\x80\xFD[P`\x046\x10a\x01BW`\x005`\xE0\x1C\x80cW\x08\x92\xC8\x11a\0\xB8W\x80c\x89\xEC\x0B\x93\x11a\0|W\x80c\x89\xEC\x0B\x93\x14a\x03'W\x80c\x91\xD1HT\x14a\x03:W\x80c\x9F)7\x0B\x14a\x03MW\x80c\xA2\x17\xFD\xDF\x14a\x03`W\x80c\xD0oh\x02\x14a\x03hW\x80c\xD5Gt\x1F\x14a\x03{W`\0\x80\xFD[\x80cW\x08\x92\xC8\x14a\x02\x8DW\x80cY\xB6L]\x14a\x02\xA0W\x80co\nC\xC7\x14a\x02\xC0W\x80c\x82+\xA4\x0B\x14a\x02\xD3W\x80c\x87\xA4\x1B\x81\x14a\x02\xFAW`\0\x80\xFD[\x80c//\xF1]\x11a\x01\nW\x80c//\xF1]\x14a\x02\x0CW\x80c6V\x8A\xBE\x14a\x02!W\x80c<~Y\x99\x14a\x024W\x80c?\xF4!\xE9\x14a\x02TW\x80cHMZ:\x14a\x02gW\x80cR\xB6+>\x14a\x02zW`\0\x80\xFD[\x80c\x01\xFF\xC9\xA7\x14a\x01GW\x80c\x06\xA0\x9D\xEA\x14a\x01oW\x80c\x12\x1Eb\x0E\x14a\x01\x9AW\x80c$\x8A\x9C\xA3\x14a\x01\xBBW\x80c&)Jw\x14a\x01\xECW[`\0\x80\xFD[a\x01Za\x01U6`\x04a$IV[a\x03\x8EV[`@Q\x90\x15\x15\x81R` \x01[`@Q\x80\x91\x03\x90\xF3[a\x01\x82a\x01}6`\x04a$\x88V[a\x03\xC5V[`@Q`\x01`\x01`@\x1B\x03\x90\x91\x16\x81R` \x01a\x01fV[a\x01\xADa\x01\xA86`\x04a$\x88V[a\x03\xD0V[`@Qa\x01f\x92\x91\x90a$\xF5V[a\x01\xDEa\x01\xC96`\x04a%\x19V[`\0\x90\x81R` \x81\x90R`@\x90 `\x01\x01T\x90V[`@Q\x90\x81R` \x01a\x01fV[a\x01\xFFa\x01\xFA6`\x04a%NV[a\x03\xF1V[`@Qa\x01f\x91\x90a%iV[a\x02\x1Fa\x02\x1A6`\x04a%\xCBV[a\x04\xE0V[\0[a\x02\x1Fa\x02/6`\x04a%\xCBV[a\x05\nV[a\x02Ga\x02B6`\x04a$\x88V[a\x05\x8DV[`@Qa\x01f\x91\x90a%\xF7V[a\x01Za\x02b6`\x04a$\x88V[a\x05\xABV[a\x02Ga\x02u6`\x04a$\x88V[a\x05\xB6V[a\x02\x1Fa\x02\x886`\x04a&lV[a\x05\xD4V[a\x02\x1Fa\x02\x9B6`\x04a&\xBEV[a\x07\rV[a\x02\xB3a\x02\xAE6`\x04a'WV[a\t'V[`@Qa\x01f\x91\x90a'\xA7V[a\x02\xB3a\x02\xCE6`\x04a(AV[a\tuV[a\x01\xDE\x7F\xAF\xDAe\x8E\xE71\xB8\xF8b\x92\xE3\xB5*1\x154\xCD\x93d+\x12\xA6\x98\x01$91n\x0C:\t\x95\x81V[a\x03\ra\x03\x086`\x04a$\x88V[a\t\xC2V[`@\x80Q`\x07\x93\x84\x0B\x81R\x91\x90\x92\x0B` \x82\x01R\x01a\x01fV[a\x02Ga\x0356`\x04a$\x88V[a\t\xD0V[a\x01Za\x03H6`\x04a%\xCBV[a\t\xEEV[a\x03\ra\x03[6`\x04a$\x88V[a\n\x17V[a\x01\xDE`\0\x81V[a\x01\x82a\x03v6`\x04a$\x88V[a\n%V[a\x02\x1Fa\x03\x896`\x04a%\xCBV[a\n0V[`\0`\x01`\x01`\xE0\x1B\x03\x19\x82\x16cye\xDB\x0B`\xE0\x1B\x14\x80a\x03\xBFWPc\x01\xFF\xC9\xA7`\xE0\x1B`\x01`\x01`\xE0\x1B\x03\x19\x83\x16\x14[\x92\x91PPV[`\0a\x03\xBF\x82a\nUV[```\0\x80a\x03\xDE\x84a\n\x93V[\x80Q` \x90\x91\x01Q\x90\x95\x90\x94P\x92PPPV[`\x01`\x01`\xA0\x1B\x03\x81\x16`\0\x90\x81R`\x02` \x90\x81R`@\x80\x83 \x80T\x82Q\x81\x85\x02\x81\x01\x85\x01\x90\x93R\x80\x83R``\x94\x92\x93\x91\x92\x90\x91\x84\x01[\x82\x82\x10\x15a\x04\xD5W\x83\x82\x90`\0R` `\0 \x01\x80Ta\x04H\x90a(\x8CV[\x80`\x1F\x01` \x80\x91\x04\x02` \x01`@Q\x90\x81\x01`@R\x80\x92\x91\x90\x81\x81R` \x01\x82\x80Ta\x04t\x90a(\x8CV[\x80\x15a\x04\xC1W\x80`\x1F\x10a\x04\x96Wa\x01\0\x80\x83T\x04\x02\x83R\x91` \x01\x91a\x04\xC1V[\x82\x01\x91\x90`\0R` `\0 \x90[\x81T\x81R\x90`\x01\x01\x90` \x01\x80\x83\x11a\x04\xA4W\x82\x90\x03`\x1F\x16\x82\x01\x91[PPPPP\x81R` \x01\x90`\x01\x01\x90a\x04)V[PPPP\x90P\x91\x90PV[`\0\x82\x81R` \x81\x90R`@\x90 `\x01\x01Ta\x04\xFB\x81a\n\xDDV[a\x05\x05\x83\x83a\n\xEAV[PPPV[`\x01`\x01`\xA0\x1B\x03\x81\x163\x14a\x05\x7FW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`/`$\x82\x01R\x7FAccessControl: can only renounce`D\x82\x01Rn\x1097\xB62\xB9\x9037\xB9\x109\xB2\xB63`\x89\x1B`d\x82\x01R`\x84\x01[`@Q\x80\x91\x03\x90\xFD[a\x05\x89\x82\x82a\x0BnV[PPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01Ra\x03\xBF\x82a\x0B\xD3V[`\0a\x03\xBF\x82a\x0C\x1DV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01Ra\x03\xBF\x82a\x0CSV[\x7F\xAF\xDAe\x8E\xE71\xB8\xF8b\x92\xE3\xB5*1\x154\xCD\x93d+\x12\xA6\x98\x01$91n\x0C:\t\x95a\x05\xFE\x81a\n\xDDV[`\0`\x01`\x01`\xA0\x1B\x03\x16`\x01\x84\x84`@Qa\x06\x1B\x92\x91\x90a(\xC6V[\x90\x81R`@Q\x90\x81\x90\x03` \x01\x90 T`\x01`\x01`\xA0\x1B\x03\x16\x14a\x06VW\x82\x82`@Qc\\x\xF6\xED`\xE1\x1B\x81R`\x04\x01a\x05v\x92\x91\x90a(\xD6V[\x83`\x01\x84\x84`@Qa\x06i\x92\x91\x90a(\xC6V[\x90\x81R`@\x80Q` \x92\x81\x90\x03\x83\x01\x90 \x80T`\x01`\x01`\xA0\x1B\x03\x19\x16`\x01`\x01`\xA0\x1B\x03\x94\x85\x16\x17\x90U\x91\x86\x16`\0\x90\x81R`\x02\x82R\x91\x82 \x80T`\x01\x81\x01\x82U\x90\x83R\x91 \x01a\x06\xBC\x83\x85\x83a)iV[P\x83`\x01`\x01`\xA0\x1B\x03\x16\x83\x83`@Qa\x06\xD7\x92\x91\x90a(\xC6V[`@Q\x90\x81\x90\x03\x81 \x90\x7F\xF8\xDE\xBC/\x17E\xEB\xA8i\t\x89\x0F-\xC0abG\x05\xC7C)4\x88)\xE0J\xBAC\xC0\x15\xB9\xA2\x90`\0\x90\xA3PPPPV[\x7F\xAF\xDAe\x8E\xE71\xB8\xF8b\x92\xE3\xB5*1\x154\xCD\x93d+\x12\xA6\x98\x01$91n\x0C:\t\x95a\x077\x81a\n\xDDV[`\0C\x90P`\0`\x01\x87\x87`@Qa\x07P\x92\x91\x90a(\xC6V[\x90\x81R`@Q\x90\x81\x90\x03` \x01\x90 T`\x01`\x01`\xA0\x1B\x03\x16\x90P\x80a\x07\x8DW\x86\x86`@Qc\x15\xE6\xE0\xEB`\xE2\x1B\x81R`\x04\x01a\x05v\x92\x91\x90a(\xD6V[`\0[\x84\x81\x10\x15a\t\x1DW`\x04\x88\x88`@Qa\x07\xAA\x92\x91\x90a(\xC6V[\x90\x81R` \x01`@Q\x80\x91\x03\x90 `\0\x84\x81R` \x01\x90\x81R` \x01`\0 \x86\x86\x83\x81\x81\x10a\x07\xDBWa\x07\xDBa*)V[\x90P` \x02\x81\x01\x90a\x07\xED\x91\x90a*?V[\x81T`\x01\x81\x01\x83U`\0\x92\x83R` \x90\x92 \x90\x91`\x03\x02\x01a\x08\x0F\x82\x82a*\xA5V[PP`\x03\x88\x88`@Qa\x08#\x92\x91\x90a(\xC6V[\x90\x81R`@Q\x90\x81\x90\x03` \x01\x90 \x80T\x90`\0a\x08@\x83a+\xC6V[\x91\x90PUP\x81`\x01`\x01`\xA0\x1B\x03\x16\x88\x88`@Qa\x08_\x92\x91\x90a(\xC6V[`@Q\x80\x91\x03\x90 \x87\x87\x84\x81\x81\x10a\x08yWa\x08ya*)V[\x90P` \x02\x81\x01\x90a\x08\x8B\x91\x90a*?V[a\x08\x99\x90` \x81\x01\x90a$\x88V[`\x01`\x01`@\x1B\x03\x16\x7Fy\xB3\x877\xA5?\x0B\xC2.4\x83sU\xA5\xC9\xD1\xBF\xCD\xDF\x81|\xB0\x02/\x82\xFE\x93\x8B\x05\x88\xBF?\x89\x89\x86\x81\x81\x10a\x08\xD5Wa\x08\xD5a*)V[\x90P` \x02\x81\x01\x90a\x08\xE7\x91\x90a*?V[a\x08\xF5\x90`@\x81\x01\x90a*_V[`@Qa\t\x03\x92\x91\x90a(\xD6V[`@Q\x80\x91\x03\x90\xA4\x80a\t\x15\x81a+\xC6V[\x91PPa\x07\x90V[PPPPPPPPV[```\0`\x03\x86\x86`@Qa\t=\x92\x91\x90a(\xC6V[\x90\x81R` \x01`@Q\x80\x91\x03\x90 T\x90P\x80\x83\x11a\t[W\x82a\t]V[\x80[\x92Pa\tk\x86\x86\x86\x86a\x0C\x92V[\x96\x95PPPPPPV[```\0`\x03\x85\x85`@Qa\t\x8B\x92\x91\x90a(\xC6V[\x90\x81R` \x01`@Q\x80\x91\x03\x90 T\x90P\x80\x83\x11a\t\xA9W\x82a\t\xABV[\x80[\x92Pa\t\xB9\x85\x85C\x86a\x0C\x92V[\x95\x94PPPPPV[`\0\x80`\0a\x03\xDE\x84a\x0FlV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01Ra\x03\xBF\x82a\x0F\xB5V[`\0\x91\x82R` \x82\x81R`@\x80\x84 `\x01`\x01`\xA0\x1B\x03\x93\x90\x93\x16\x84R\x91\x90R\x90 T`\xFF\x16\x90V[`\0\x80`\0a\x03\xDE\x84a\x0F\xF4V[`\0a\x03\xBF\x82a\x102V[`\0\x82\x81R` \x81\x90R`@\x90 `\x01\x01Ta\nK\x81a\n\xDDV[a\x05\x05\x83\x83a\x0BnV[`\0\x80a\nj\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\n\x80`\x05c\x07\xA1\xF0Q`Q\x85a\x10\x95V[\x90Pa\n\x8B\x81a\x10\xBAV[\x94\x93PPPPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`\0a\n\xBC\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\n\xD2`\x05c\x02\xC3s\x86`Q\x85a\x10\x95V[\x90Pa\n\x8B\x81a\x10\xD1V[a\n\xE7\x813a\x11\x08V[PV[a\n\xF4\x82\x82a\t\xEEV[a\x05\x89W`\0\x82\x81R` \x81\x81R`@\x80\x83 `\x01`\x01`\xA0\x1B\x03\x85\x16\x84R\x90\x91R\x90 \x80T`\xFF\x19\x16`\x01\x17\x90Ua\x0B*3\x90V[`\x01`\x01`\xA0\x1B\x03\x16\x81`\x01`\x01`\xA0\x1B\x03\x16\x83\x7F/\x87\x88\x11~~\xFF\x1D\x82\xE9&\xECyI\x01\xD1|x\x02JP'\t@0E@\xA73eo\r`@Q`@Q\x80\x91\x03\x90\xA4PPV[a\x0Bx\x82\x82a\t\xEEV[\x15a\x05\x89W`\0\x82\x81R` \x81\x81R`@\x80\x83 `\x01`\x01`\xA0\x1B\x03\x85\x16\x80\x85R\x92R\x80\x83 \x80T`\xFF\x19\x16\x90UQ3\x92\x85\x91\x7F\xF69\x1F\\2\xD9\xC6\x9D*G\xEAg\x0BD)t\xB595\xD1\xED\xC7\xFDd\xEB!\xE0G\xA89\x17\x1B\x91\x90\xA4PPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`\0a\x0B\xFC\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0C\x12`\x05c\xB2\x05\x9CI`Q\x85a\x10\x95V[\x90Pa\n\x8B\x81a\x11aV[`\0\x80a\x0C2\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0CH`\x05c\x9C\x9A\xC8\x19`Q\x85a\x10\x95V[\x90Pa\n\x8B\x81a\x11\xC5V[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`\0a\x0C|\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0C\x12`\x05c\xFF\x88\xE8<`Q\x85a\x10\x95V[```\0\x80\x83`\x01`\x01`@\x1B\x03\x81\x11\x15a\x0C\xAFWa\x0C\xAFa)\x05V[`@Q\x90\x80\x82R\x80` \x02` \x01\x82\x01`@R\x80\x15a\r\rW\x81` \x01[a\x0C\xFA`@Q\x80``\x01`@R\x80`\0`\x01`\x01`@\x1B\x03\x16\x81R` \x01``\x81R` \x01``\x81RP\x90V[\x81R` \x01\x90`\x01\x90\x03\x90\x81a\x0C\xCDW\x90P[P\x90P\x84[\x84\x83\x10\x15a\x0F_W`\0`\x04\x89\x89`@Qa\r.\x92\x91\x90a(\xC6V[\x90\x81R`@\x80Q\x91\x82\x90\x03` \x90\x81\x01\x83 `\0\x86\x81R\x90\x82R\x82\x81 \x80T\x80\x84\x02\x86\x01\x84\x01\x90\x94R\x83\x85R\x92\x91\x84\x01[\x82\x82\x10\x15a\x0E\xCBW`\0\x84\x81R` \x90\x81\x90 `@\x80Q``\x81\x01\x90\x91R`\x03\x85\x02\x90\x91\x01\x80T`\x01`\x01`@\x1B\x03\x16\x82R`\x01\x81\x01\x80T\x92\x93\x91\x92\x91\x84\x01\x91a\r\xA8\x90a(\x8CV[\x80`\x1F\x01` \x80\x91\x04\x02` \x01`@Q\x90\x81\x01`@R\x80\x92\x91\x90\x81\x81R` \x01\x82\x80Ta\r\xD4\x90a(\x8CV[\x80\x15a\x0E!W\x80`\x1F\x10a\r\xF6Wa\x01\0\x80\x83T\x04\x02\x83R\x91` \x01\x91a\x0E!V[\x82\x01\x91\x90`\0R` `\0 \x90[\x81T\x81R\x90`\x01\x01\x90` \x01\x80\x83\x11a\x0E\x04W\x82\x90\x03`\x1F\x16\x82\x01\x91[PPPPP\x81R` \x01`\x02\x82\x01\x80Ta\x0E:\x90a(\x8CV[\x80`\x1F\x01` \x80\x91\x04\x02` \x01`@Q\x90\x81\x01`@R\x80\x92\x91\x90\x81\x81R` \x01\x82\x80Ta\x0Ef\x90a(\x8CV[\x80\x15a\x0E\xB3W\x80`\x1F\x10a\x0E\x88Wa\x01\0\x80\x83T\x04\x02\x83R\x91` \x01\x91a\x0E\xB3V[\x82\x01\x91\x90`\0R` `\0 \x90[\x81T\x81R\x90`\x01\x01\x90` \x01\x80\x83\x11a\x0E\x96W\x82\x90\x03`\x1F\x16\x82\x01\x91[PPPPP\x81RPP\x81R` \x01\x90`\x01\x01\x90a\r_V[PPPP\x90P`\0[\x81Q\x81\x10\x15a\x0F=W\x86\x85\x10\x15a\x0F=W\x81\x81\x81Q\x81\x10a\x0E\xF7Wa\x0E\xF7a*)V[` \x02` \x01\x01Q\x84\x86\x81Q\x81\x10a\x0F\x11Wa\x0F\x11a*)V[` \x02` \x01\x01\x81\x90RP\x84\x80a\x0F'\x90a+\xC6V[\x95PP\x80\x80a\x0F5\x90a+\xC6V[\x91PPa\x0E\xD4V[P\x81`\0\x03a\x0FLWPa\x0F_V[\x81a\x0FV\x81a+\xDFV[\x92PPPa\r\x12V[P\x90\x81R\x95\x94PPPPPV[`@\x80Q\x80\x82\x01\x90\x91R`\0\x80\x82R` \x82\x01R`\0a\x0F\x94\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0F\xAA`\x05c\t\xC3\x0B `Q\x85a\x10\x95V[\x90Pa\n\x8B\x81a\x11\xD3V[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`\0a\x0F\xDE\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0C\x12`\x05c\x0B\xF4lW`Q\x85a\x10\x95V[`@\x80Q\x80\x82\x01\x90\x91R`\0\x80\x82R` \x82\x01R`\0a\x10\x1C\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0F\xAA`\x05c\x99\x04\xF2\xFF`Q\x85a\x10\x95V[`\0\x80a\x10G\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\n\x80`\x05c7\xBC6\xDA`Q\x85a\x10\x95V[```\0a\x10s\x83`\x01`\x01`@\x1B\x03\x16a\x127V[\x90P`\0a\x10\x80\x82a\x12\x85V[\x90Pa\x10\x8C\x81\x85a\x12\xA6V[a\n\x8B\x81a\x12\xB2V[``a\x12\xFD\x80a\x10\xAF\x87\x87\x87\x87`\0`\x01c\xFF\xFF\xFF\xFF\x88\x16V[\x97\x96PPPPPPPV[`\0\x80\x80a\x10\xC8\x84\x82a\x13\xD7V[P\x94\x93PPPPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01\x81\x90R\x90a\x10\xC8\x84\x83a\x14dV[a\x11\x12\x82\x82a\t\xEEV[a\x05\x89Wa\x11\x1F\x81a\x16\x12V[a\x11*\x83` a\x16$V[`@Q` \x01a\x11;\x92\x91\x90a+\xF6V[`@\x80Q`\x1F\x19\x81\x84\x03\x01\x81R\x90\x82\x90RbF\x1B\xCD`\xE5\x1B\x82Ra\x05v\x91`\x04\x01a,kV[`@\x80Q\x80\x82\x01\x90\x91R``\x80\x82R`\0` \x83\x01\x81\x90R\x83Q\x15a\x11\x9FWa\x11\x8A\x84\x82a\x17\xC6V[\x81Q\x91\x93P\x91P\x15a\x11\x9FWa\n\x8B\x82a\x19kV[PP`@\x80Q`\0\x81\x83\x01\x81\x81R``\x83\x01\x90\x93R\x91\x81R` \x81\x01\x91\x90\x91R\x92\x91PPV[`\0\x80\x80a\x10\xC8\x84\x82a\x1A\xC7V[`@\x80Q\x80\x82\x01\x90\x91R`\0\x80\x82R` \x82\x01R`\0\x80a\x11\xF4\x84\x82a\x1BbV[\x92P\x90P`\x02\x81\x14a\x12\x08Wa\x12\x08a,~V[a\x12\x12\x84\x83a\x1B\xD5V[`\x07\x91\x90\x91\x0B\x84R\x91Pa\x12&\x84\x83a\x1B\xD5V[P`\x07\x0B` \x84\x01RP\x90\x92\x91PPV[`\0`\x17\x82\x11a\x12IWP`\x01\x91\x90PV[`\xFF\x82\x11a\x12YWP`\x02\x91\x90PV[a\xFF\xFF\x82\x11a\x12jWP`\x03\x91\x90PV[c\xFF\xFF\xFF\xFF\x82\x11a\x12}WP`\x05\x91\x90PV[P`\t\x91\x90PV[a\x12\x8Da$\x14V[\x80Qa\x12\x99\x90\x83a\x1B\xEFV[P`\0` \x82\x01R\x91\x90PV[a\x05\x89\x82`\0\x83a\x1CfV[``\x81` \x01Q`\0\x14a\x12\xF7W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0C`$\x82\x01Rk$\xB7;0\xB64\xB2\x10!\xA1'\xA9`\xA1\x1B`D\x82\x01R`d\x01a\x05vV[PQQ\x90V[``a\x13\x10`\x05`\x7F`\x99\x1B\x01\x84a\x1D\x85V[`\0\x80`\x05`\x7F`\x99\x1B\x01\x88\x86\x86a\x13)W`\0a\x13,V[`\x01[\x8A\x8A\x8E`@Q` \x01a\x13D\x96\x95\x94\x93\x92\x91\x90a,\x94V[`@\x80Q`\x1F\x19\x81\x84\x03\x01\x81R\x90\x82\x90Ra\x13^\x91a,\xE3V[`\0`@Q\x80\x83\x03\x81\x85Z\xF4\x91PP=\x80`\0\x81\x14a\x13\x99W`@Q\x91P`\x1F\x19`?=\x01\x16\x82\x01`@R=\x82R=`\0` \x84\x01>a\x13\x9EV[``\x91P[P\x91P\x91P\x81a\x13\xC1W`@Qc\x8A}\xB5\xBF`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[a\x13\xCA\x81a\x1D\xD3V[\x99\x98PPPPPPPPPV[`\0\x80`\0\x80a\x13\xE7\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16\x15a\x14VW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7Finvalid maj (expected MajUnsigne`D\x82\x01RddInt)`\xD8\x1B`d\x82\x01R`\x84\x01a\x05vV[\x92P\x83\x91PP[\x92P\x92\x90PV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`\0\x80`\0a\x14\x88\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x02\x14\x80a\x14\xADWP`\xFF\x82\x16`\x03\x14[a\x15\x17W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7Finvalid maj (expected MajByteStr`D\x82\x01Rting or MajTextString)`X\x1B`d\x82\x01R`\x84\x01a\x05vV[`\0a\x15#\x82\x87a,\xF5V[\x90P`\0\x82`\x01`\x01`@\x1B\x03\x81\x11\x15a\x15?Wa\x15?a)\x05V[`@Q\x90\x80\x82R\x80`\x1F\x01`\x1F\x19\x16` \x01\x82\x01`@R\x80\x15a\x15iW` \x82\x01\x81\x806\x837\x01\x90P[P\x90P`\0\x87[\x83\x81\x10\x15a\x15\xDEW\x89\x81\x81Q\x81\x10a\x15\x8AWa\x15\x8Aa*)V[` \x01\x01Q`\xF8\x1C`\xF8\x1B\x83\x83\x81Q\x81\x10a\x15\xA7Wa\x15\xA7a*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP\x81a\x15\xC8\x81a+\xC6V[\x92PP\x80\x80a\x15\xD6\x90a+\xC6V[\x91PPa\x15pV[P`@\x80Q\x80\x82\x01\x90\x91R\x82\x81R`\xFF\x86\x16`\x03\x14` \x82\x01Ra\x16\x02\x85\x8Aa,\xF5V[\x96P\x96PPPPPP\x92P\x92\x90PV[``a\x03\xBF`\x01`\x01`\xA0\x1B\x03\x83\x16`\x14[```\0a\x163\x83`\x02a-\x08V[a\x16>\x90`\x02a,\xF5V[`\x01`\x01`@\x1B\x03\x81\x11\x15a\x16UWa\x16Ua)\x05V[`@Q\x90\x80\x82R\x80`\x1F\x01`\x1F\x19\x16` \x01\x82\x01`@R\x80\x15a\x16\x7FW` \x82\x01\x81\x806\x837\x01\x90P[P\x90P`\x03`\xFC\x1B\x81`\0\x81Q\x81\x10a\x16\x9AWa\x16\x9Aa*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP`\x0F`\xFB\x1B\x81`\x01\x81Q\x81\x10a\x16\xC9Wa\x16\xC9a*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP`\0a\x16\xED\x84`\x02a-\x08V[a\x16\xF8\x90`\x01a,\xF5V[\x90P[`\x01\x81\x11\x15a\x17pWo\x18\x18\x99\x19\x9A\x1A\x9B\x1B\x9C\x1C\xB0\xB11\xB22\xB3`\x81\x1B\x85`\x0F\x16`\x10\x81\x10a\x17,Wa\x17,a*)V[\x1A`\xF8\x1B\x82\x82\x81Q\x81\x10a\x17BWa\x17Ba*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP`\x04\x94\x90\x94\x1C\x93a\x17i\x81a+\xDFV[\x90Pa\x16\xFBV[P\x83\x15a\x17\xBFW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01\x81\x90R`$\x82\x01R\x7FStrings: hex length insufficient`D\x82\x01R`d\x01a\x05vV[\x93\x92PPPV[```\0\x80`\0a\x17\xD7\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x06\x14\x80a\x17\xFCWP`\xFF\x82\x16`\x02\x14[a\x18_W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`.`$\x82\x01R\x7Finvalid maj (expected MajTag or `D\x82\x01RmMajByteString)`\x90\x1B`d\x82\x01R`\x84\x01a\x05vV[`\x05\x19`\xFF\x83\x16\x01a\x18\x98Wa\x18u\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x02\x14a\x18\x98Wa\x18\x98a,~V[`\0a\x18\xA4\x82\x87a,\xF5V[\x90P`\0\x82`\x01`\x01`@\x1B\x03\x81\x11\x15a\x18\xC0Wa\x18\xC0a)\x05V[`@Q\x90\x80\x82R\x80`\x1F\x01`\x1F\x19\x16` \x01\x82\x01`@R\x80\x15a\x18\xEAW` \x82\x01\x81\x806\x837\x01\x90P[P\x90P`\0\x87[\x83\x81\x10\x15a\x19_W\x89\x81\x81Q\x81\x10a\x19\x0BWa\x19\x0Ba*)V[` \x01\x01Q`\xF8\x1C`\xF8\x1B\x83\x83\x81Q\x81\x10a\x19(Wa\x19(a*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP\x81a\x19I\x81a+\xC6V[\x92PP\x80\x80a\x19W\x90a+\xC6V[\x91PPa\x18\xF1V[P\x81a\x16\x02\x85\x8Aa,\xF5V[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R\x81Q`\0\x03a\x19\xB4WPP`@\x80Q`\x80\x81\x01\x82R`\x01\x91\x81\x01\x91\x82R`\0``\x82\x01\x81\x90R\x91\x81R` \x81\x01\x91\x90\x91R\x90V[`\0`\x01\x83Qa\x19\xC4\x91\x90a-\x1FV[`\x01`\x01`@\x1B\x03\x81\x11\x15a\x19\xDBWa\x19\xDBa)\x05V[`@Q\x90\x80\x82R\x80`\x1F\x01`\x1F\x19\x16` \x01\x82\x01`@R\x80\x15a\x1A\x05W` \x82\x01\x81\x806\x837\x01\x90P[P\x90P`\0\x83`\0\x81Q\x81\x10a\x1A\x1DWa\x1A\x1Da*)V[\x01` \x01Q`\x01`\x01`\xF8\x1B\x03\x19\x16`\x01`\xF8\x1B\x03a\x1A:WP`\x01[`\x01[\x84Q\x81\x10\x15a\x1A\xACW\x84\x81\x81Q\x81\x10a\x1AXWa\x1AXa*)V[\x01` \x01Q`\x01`\x01`\xF8\x1B\x03\x19\x16\x83a\x1As`\x01\x84a-\x1FV[\x81Q\x81\x10a\x1A\x83Wa\x1A\x83a*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP\x80a\x1A\xA4\x81a+\xC6V[\x91PPa\x1A=V[P`@\x80Q\x80\x82\x01\x90\x91R\x91\x82R\x15\x15` \x82\x01R\x92\x91PPV[`\0\x80`\0\x80a\x1A\xD7\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x07\x14a\x1B:W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x1F`$\x82\x01R\x7Finvalid maj (expected MajOther)\0`D\x82\x01R`d\x01a\x05vV[`\x15\x81\x14\x80a\x1BIWP`\x14\x81\x14[a\x1BUWa\x1BUa,~V[`\x14\x14\x15\x95\x93\x94PPPPV[`\0\x80`\0\x80a\x1Br\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x04\x14a\x14VW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x1F`$\x82\x01R\x7Finvalid maj (expected MajArray)\0`D\x82\x01R`d\x01a\x05vV[`\0\x80\x80a\x1B\xE3\x85\x85a \x90V[\x90\x96\x90\x95P\x93PPPPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01Ra\x1C\x0F` \x83a-2V[\x15a\x1C7Wa\x1C\x1F` \x83a-2V[a\x1C*\x90` a-\x1FV[a\x1C4\x90\x83a,\xF5V[\x91P[` \x80\x84\x01\x83\x90R`@Q\x80\x85R`\0\x81R\x90\x81\x84\x01\x01\x81\x81\x10\x15a\x1C[W`\0\x80\xFD[`@RP\x91\x92\x91PPV[`\x17\x81`\x01`\x01`@\x1B\x03\x16\x11a\x1C\x92W\x82Qa\x1C\x8C\x90`\xE0`\x05\x85\x90\x1B\x16\x83\x17a!-V[PPPPV[`\xFF\x81`\x01`\x01`@\x1B\x03\x16\x11a\x1C\xD2W\x82Qa\x1C\xBA\x90`\x18a\x1F\xE0`\x05\x86\x90\x1B\x16\x17a!-V[P\x82Qa\x1C\x8C\x90`\x01`\x01`@\x1B\x03\x83\x16`\x01a!\x96V[a\xFF\xFF\x81`\x01`\x01`@\x1B\x03\x16\x11a\x1D\x13W\x82Qa\x1C\xFB\x90`\x19a\x1F\xE0`\x05\x86\x90\x1B\x16\x17a!-V[P\x82Qa\x1C\x8C\x90`\x01`\x01`@\x1B\x03\x83\x16`\x02a!\x96V[c\xFF\xFF\xFF\xFF\x81`\x01`\x01`@\x1B\x03\x16\x11a\x1DVW\x82Qa\x1D>\x90`\x1Aa\x1F\xE0`\x05\x86\x90\x1B\x16\x17a!-V[P\x82Qa\x1C\x8C\x90`\x01`\x01`@\x1B\x03\x83\x16`\x04a!\x96V[\x82Qa\x1Dm\x90`\x1Ba\x1F\xE0`\x05\x86\x90\x1B\x16\x17a!-V[P\x82Qa\x1C\x8C\x90`\x01`\x01`@\x1B\x03\x83\x16`\x08a!\x96V[G\x81\x81\x10\x15a\x1D\xB1W`@QcG\x87\xA1\x03`\xE1\x1B\x81R`\x04\x81\x01\x82\x90R`$\x81\x01\x83\x90R`D\x01a\x05vV[\x82?\x15\x15\x80a\x1C\x8CW`@Qc\x06M\x95K`\xE4\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[```\0\x80`\0\x84\x80` \x01\x90Q\x81\x01\x90a\x1D\xEE\x91\x90a-TV[\x91\x94P\x92P\x90P`\x01`\x01`@\x1B\x03\x82\x16a\x1E(W\x80Q\x15a\x1E#W`@Qc\x0Et\x99\x07`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[a\x1E\x94V[`\x01`\x01`@\x1B\x03\x82\x16`Q\x14\x80a\x1EIWP`\x01`\x01`@\x1B\x03\x82\x16`q\x14[\x15a\x1EpW\x80Q`\0\x03a\x1E#W`@Qc\x0Et\x99\x07`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[`@Qc\xF1\xF6\xBC\xED`\xE0\x1B\x81R`\x01`\x01`@\x1B\x03\x83\x16`\x04\x82\x01R`$\x01a\x05vV[\x82\x15a\n\x8BW`@Qc\xD4\xBBfq`\xE0\x1B\x81R`\x04\x81\x01\x84\x90R`$\x01a\x05vV[`\0\x80`\0\x80a\x1E\xC6\x86\x86a\"\x1BV[\x90Pa\x1E\xD3`\x01\x86a,\xF5V[\x94P`\x07`\x05\x82\x90\x1C\x16`\x1F\x82\x16`\x1C\x81\x10a\x1F?W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7Fcannot handle headers with extra`D\x82\x01Rd > 27`\xD8\x1B`d\x82\x01R`\x84\x01a\x05vV[`\x18\x81`\xFF\x16\x10\x15a\x1F]W\x90\x94P`\xFF\x16\x92P\x84\x91Pa \x89\x90PV[\x80`\xFF\x16`\x18\x03a\x1F\xD9W`\0a\x1Ft\x89\x89a\"\x1BV[\x90Pa\x1F\x81`\x01\x89a,\xF5V[\x97P`\x18\x81`\xFF\x16\x10\x15a\x1F\xC6W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0C`$\x82\x01Rk4\xB7;0\xB64\xB2\x101\xB17\xB9`\xA1\x1B`D\x82\x01R`d\x01a\x05vV[\x91\x95PP`\xFF\x16\x92P\x84\x91Pa \x89\x90PV[\x80`\xFF\x16`\x19\x03a \x13W`\0a\x1F\xF0\x89\x89a\"jV[\x90Pa\x1F\xFD`\x02\x89a,\xF5V[\x97P\x91\x95PPa\xFF\xFF\x16\x92P\x84\x91Pa \x89\x90PV[\x80`\xFF\x16`\x1A\x03a OW`\0a *\x89\x89a\"\xA3V[\x90Pa 7`\x04\x89a,\xF5V[\x97P\x91\x95PPc\xFF\xFF\xFF\xFF\x16\x92P\x84\x91Pa \x89\x90PV[\x80`\xFF\x16`\x1B\x14a bWa ba,~V[`\0a n\x89\x89a\"\xDCV[\x90Pa {`\x08\x89a,\xF5V[\x97P\x91\x95P\x90\x93P\x85\x92PPP[\x92P\x92P\x92V[`\0\x80`\0\x80a \xA0\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x01\x14\x80a \xC3WP`\xFF\x82\x16\x15[a\x14VW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7Finvalid maj (expected MajSignedI`D\x82\x01Rtnt or MajUnsignedInt)`X\x1B`d\x82\x01R`\x84\x01a\x05vV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R\x82QQ`\0a!R\x82`\x01a,\xF5V[\x90P\x84` \x01Q\x82\x10a!sWa!s\x85a!n\x83`\x02a-\x08V[a#\x15V[\x84Q` \x83\x82\x01\x01\x85\x81SP\x80Q\x82\x11\x15a!\x8CW\x81\x81R[P\x93\x94\x93PPPPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R\x83QQ`\0a!\xBA\x82\x85a,\xF5V[\x90P\x85` \x01Q\x81\x11\x15a!\xD7Wa!\xD7\x86a!n\x83`\x02a-\x08V[`\0`\x01a!\xE7\x86a\x01\0a/\x03V[a!\xF1\x91\x90a-\x1FV[\x90P\x86Q\x82\x81\x01\x87\x83\x19\x82Q\x16\x17\x81RP\x80Q\x83\x11\x15a\"\x0FW\x82\x81R[P\x95\x96\x95PPPPPPV[`\0a\"(\x82`\x01a,\xF5V[\x83Q\x10\x15a\"HW`@QbF\x1B\xCD`\xE5\x1B\x81R`\x04\x01a\x05v\x90a/\x0FV[\x82\x82\x81Q\x81\x10a\"ZWa\"Za*)V[\x01` \x01Q`\xF8\x1C\x90P\x92\x91PPV[`\0a\"w\x82`\x02a,\xF5V[\x83Q\x10\x15a\"\x97W`@QbF\x1B\xCD`\xE5\x1B\x81R`\x04\x01a\x05v\x90a/\x0FV[P\x01` \x01Q`\xF0\x1C\x90V[`\0a\"\xB0\x82`\x04a,\xF5V[\x83Q\x10\x15a\"\xD0W`@QbF\x1B\xCD`\xE5\x1B\x81R`\x04\x01a\x05v\x90a/\x0FV[P\x01` \x01Q`\xE0\x1C\x90V[`\0a\"\xE9\x82`\x08a,\xF5V[\x83Q\x10\x15a#\tW`@QbF\x1B\xCD`\xE5\x1B\x81R`\x04\x01a\x05v\x90a/\x0FV[P\x01` \x01Q`\xC0\x1C\x90V[\x81Qa#!\x83\x83a\x1B\xEFV[Pa\x1C\x8C\x83\x82`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01Ra\x17\xBF\x83\x83\x84Q`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R\x82Q\x82\x11\x15a#fW`\0\x80\xFD[\x83QQ`\0a#u\x84\x83a,\xF5V[\x90P\x85` \x01Q\x81\x11\x15a#\x92Wa#\x92\x86a!n\x83`\x02a-\x08V[\x85Q\x80Q\x83\x82\x01` \x01\x91`\0\x91\x80\x85\x11\x15a#\xACW\x84\x82R[PPP` \x86\x01[` \x86\x10a#\xECW\x80Q\x82Ra#\xCB` \x83a,\xF5V[\x91Pa#\xD8` \x82a,\xF5V[\x90Pa#\xE5` \x87a-\x1FV[\x95Pa#\xB4V[Q\x81Q`\0\x19` \x88\x90\x03a\x01\0\n\x01\x90\x81\x16\x90\x19\x91\x90\x91\x16\x17\x90RP\x84\x91PP\x93\x92PPPV[`@Q\x80`@\x01`@R\x80a$<`@Q\x80`@\x01`@R\x80``\x81R` \x01`\0\x81RP\x90V[\x81R` \x01`\0\x81RP\x90V[`\0` \x82\x84\x03\x12\x15a$[W`\0\x80\xFD[\x815`\x01`\x01`\xE0\x1B\x03\x19\x81\x16\x81\x14a\x17\xBFW`\0\x80\xFD[`\x01`\x01`@\x1B\x03\x81\x16\x81\x14a\n\xE7W`\0\x80\xFD[`\0` \x82\x84\x03\x12\x15a$\x9AW`\0\x80\xFD[\x815a\x17\xBF\x81a$sV[`\0[\x83\x81\x10\x15a$\xC0W\x81\x81\x01Q\x83\x82\x01R` \x01a$\xA8V[PP`\0\x91\x01RV[`\0\x81Q\x80\x84Ra$\xE1\x81` \x86\x01` \x86\x01a$\xA5V[`\x1F\x01`\x1F\x19\x16\x92\x90\x92\x01` \x01\x92\x91PPV[`@\x81R`\0a%\x08`@\x83\x01\x85a$\xC9V[\x90P\x82\x15\x15` \x83\x01R\x93\x92PPPV[`\0` \x82\x84\x03\x12\x15a%+W`\0\x80\xFD[P5\x91\x90PV[\x805`\x01`\x01`\xA0\x1B\x03\x81\x16\x81\x14a%IW`\0\x80\xFD[\x91\x90PV[`\0` \x82\x84\x03\x12\x15a%`W`\0\x80\xFD[a\x17\xBF\x82a%2V[`\0` \x80\x83\x01\x81\x84R\x80\x85Q\x80\x83R`@\x86\x01\x91P`@\x81`\x05\x1B\x87\x01\x01\x92P\x83\x87\x01`\0[\x82\x81\x10\x15a%\xBEW`?\x19\x88\x86\x03\x01\x84Ra%\xAC\x85\x83Qa$\xC9V[\x94P\x92\x85\x01\x92\x90\x85\x01\x90`\x01\x01a%\x90V[P\x92\x97\x96PPPPPPPV[`\0\x80`@\x83\x85\x03\x12\x15a%\xDEW`\0\x80\xFD[\x825\x91Pa%\xEE` \x84\x01a%2V[\x90P\x92P\x92\x90PV[` \x81R`\0\x82Q`@` \x84\x01Ra&\x13``\x84\x01\x82a$\xC9V[\x90P` \x84\x01Q\x15\x15`@\x84\x01R\x80\x91PP\x92\x91PPV[`\0\x80\x83`\x1F\x84\x01\x12a&=W`\0\x80\xFD[P\x815`\x01`\x01`@\x1B\x03\x81\x11\x15a&TW`\0\x80\xFD[` \x83\x01\x91P\x83` \x82\x85\x01\x01\x11\x15a\x14]W`\0\x80\xFD[`\0\x80`\0`@\x84\x86\x03\x12\x15a&\x81W`\0\x80\xFD[a&\x8A\x84a%2V[\x92P` \x84\x015`\x01`\x01`@\x1B\x03\x81\x11\x15a&\xA5W`\0\x80\xFD[a&\xB1\x86\x82\x87\x01a&+V[\x94\x97\x90\x96P\x93\x94PPPPV[`\0\x80`\0\x80`@\x85\x87\x03\x12\x15a&\xD4W`\0\x80\xFD[\x845`\x01`\x01`@\x1B\x03\x80\x82\x11\x15a&\xEBW`\0\x80\xFD[a&\xF7\x88\x83\x89\x01a&+V[\x90\x96P\x94P` \x87\x015\x91P\x80\x82\x11\x15a'\x10W`\0\x80\xFD[\x81\x87\x01\x91P\x87`\x1F\x83\x01\x12a'$W`\0\x80\xFD[\x815\x81\x81\x11\x15a'3W`\0\x80\xFD[\x88` \x82`\x05\x1B\x85\x01\x01\x11\x15a'HW`\0\x80\xFD[\x95\x98\x94\x97PP` \x01\x94PPPV[`\0\x80`\0\x80``\x85\x87\x03\x12\x15a'mW`\0\x80\xFD[\x845`\x01`\x01`@\x1B\x03\x81\x11\x15a'\x83W`\0\x80\xFD[a'\x8F\x87\x82\x88\x01a&+V[\x90\x98\x90\x97P` \x87\x015\x96`@\x015\x95P\x93PPPPV[`\0` \x80\x83\x01\x81\x84R\x80\x85Q\x80\x83R`@\x92P\x82\x86\x01\x91P\x82\x81`\x05\x1B\x87\x01\x01\x84\x88\x01`\0[\x83\x81\x10\x15a(3W`?\x19\x89\x84\x03\x01\x85R\x81Q```\x01`\x01`@\x1B\x03\x82Q\x16\x85R\x88\x82\x01Q\x81\x8A\x87\x01Ra(\x05\x82\x87\x01\x82a$\xC9V[\x91PP\x87\x82\x01Q\x91P\x84\x81\x03\x88\x86\x01Ra(\x1F\x81\x83a$\xC9V[\x96\x89\x01\x96\x94PPP\x90\x86\x01\x90`\x01\x01a'\xCEV[P\x90\x98\x97PPPPPPPPV[`\0\x80`\0`@\x84\x86\x03\x12\x15a(VW`\0\x80\xFD[\x835`\x01`\x01`@\x1B\x03\x81\x11\x15a(lW`\0\x80\xFD[a(x\x86\x82\x87\x01a&+V[\x90\x97\x90\x96P` \x95\x90\x95\x015\x94\x93PPPPV[`\x01\x81\x81\x1C\x90\x82\x16\x80a(\xA0W`\x7F\x82\x16\x91P[` \x82\x10\x81\x03a(\xC0WcNH{q`\xE0\x1B`\0R`\"`\x04R`$`\0\xFD[P\x91\x90PV[\x81\x83\x827`\0\x91\x01\x90\x81R\x91\x90PV[` \x81R\x81` \x82\x01R\x81\x83`@\x83\x017`\0\x81\x83\x01`@\x90\x81\x01\x91\x90\x91R`\x1F\x90\x92\x01`\x1F\x19\x16\x01\x01\x91\x90PV[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[`\x1F\x82\x11\x15a\x05\x05W`\0\x81\x81R` \x81 `\x1F\x85\x01`\x05\x1C\x81\x01` \x86\x10\x15a)BWP\x80[`\x1F\x85\x01`\x05\x1C\x82\x01\x91P[\x81\x81\x10\x15a)aW\x82\x81U`\x01\x01a)NV[PPPPPPV[`\x01`\x01`@\x1B\x03\x83\x11\x15a)\x80Wa)\x80a)\x05V[a)\x94\x83a)\x8E\x83Ta(\x8CV[\x83a)\x1BV[`\0`\x1F\x84\x11`\x01\x81\x14a)\xC8W`\0\x85\x15a)\xB0WP\x83\x82\x015[`\0\x19`\x03\x87\x90\x1B\x1C\x19\x16`\x01\x86\x90\x1B\x17\x83Ua*\"V[`\0\x83\x81R` \x90 `\x1F\x19\x86\x16\x90\x83[\x82\x81\x10\x15a)\xF9W\x86\x85\x015\x82U` \x94\x85\x01\x94`\x01\x90\x92\x01\x91\x01a)\xD9V[P\x86\x82\x10\x15a*\x16W`\0\x19`\xF8\x88`\x03\x1B\x16\x1C\x19\x84\x87\x015\x16\x81U[PP`\x01\x85`\x01\x1B\x01\x83U[PPPPPV[cNH{q`\xE0\x1B`\0R`2`\x04R`$`\0\xFD[`\0\x825`^\x19\x836\x03\x01\x81\x12a*UW`\0\x80\xFD[\x91\x90\x91\x01\x92\x91PPV[`\0\x80\x835`\x1E\x19\x846\x03\x01\x81\x12a*vW`\0\x80\xFD[\x83\x01\x805\x91P`\x01`\x01`@\x1B\x03\x82\x11\x15a*\x90W`\0\x80\xFD[` \x01\x91P6\x81\x90\x03\x82\x13\x15a\x14]W`\0\x80\xFD[\x815a*\xB0\x81a$sV[\x81Tg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x19\x16`\x01`\x01`@\x1B\x03\x91\x82\x16\x17\x82U`\x01\x90\x81\x83\x01` a*\xDF\x86\x82\x01\x87a*_V[\x84\x81\x11\x15a*\xEFWa*\xEFa)\x05V[a+\x03\x81a*\xFD\x86Ta(\x8CV[\x86a)\x1BV[`\0\x94P`\x1F\x81\x11`\x01\x81\x14a+9W`\0\x82\x15a+!WP\x82\x86\x015[`\0\x19`\x03\x84\x90\x1B\x1C\x19\x16`\x01\x83\x90\x1B\x17\x85Ua+\x8EV[`\0\x85\x81R` \x90 `\x1F\x19\x83\x16\x90\x87[\x82\x81\x10\x15a+gW\x85\x89\x015\x82U\x97\x86\x01\x97\x90\x89\x01\x90\x86\x01a+JV[P\x83\x82\x10\x15a+\x84W`\0\x19`\xF8\x85`\x03\x1B\x16\x1C\x19\x88\x86\x015\x16\x81U[PP\x86\x82\x88\x1B\x01\x85U[PPPPPPPa+\xA2`@\x83\x01\x83a*_V[a\x1C\x8C\x81\x83`\x02\x86\x01a)iV[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[`\0`\x01\x82\x01a+\xD8Wa+\xD8a+\xB0V[P`\x01\x01\x90V[`\0\x81a+\xEEWa+\xEEa+\xB0V[P`\0\x19\x01\x90V[\x7FAccessControl: account \0\0\0\0\0\0\0\0\0\x81R`\0\x83Qa,.\x81`\x17\x85\x01` \x88\x01a$\xA5V[p\x01\x03K\x99\x03kK\x9B\x9BKs9\x03\x93{c)`}\x1B`\x17\x91\x84\x01\x91\x82\x01R\x83Qa,_\x81`(\x84\x01` \x88\x01a$\xA5V[\x01`(\x01\x94\x93PPPPV[` \x81R`\0a\x17\xBF` \x83\x01\x84a$\xC9V[cNH{q`\xE0\x1B`\0R`\x01`\x04R`$`\0\xFD[`\0`\x01`\x01`@\x1B\x03\x80\x89\x16\x83R\x87` \x84\x01R\x80\x87\x16`@\x84\x01R\x80\x86\x16``\x84\x01R`\xC0`\x80\x84\x01Ra,\xCD`\xC0\x84\x01\x86a$\xC9V[\x91P\x80\x84\x16`\xA0\x84\x01RP\x97\x96PPPPPPPV[`\0\x82Qa*U\x81\x84` \x87\x01a$\xA5V[\x80\x82\x01\x80\x82\x11\x15a\x03\xBFWa\x03\xBFa+\xB0V[\x80\x82\x02\x81\x15\x82\x82\x04\x84\x14\x17a\x03\xBFWa\x03\xBFa+\xB0V[\x81\x81\x03\x81\x81\x11\x15a\x03\xBFWa\x03\xBFa+\xB0V[`\0\x82a-OWcNH{q`\xE0\x1B`\0R`\x12`\x04R`$`\0\xFD[P\x06\x90V[`\0\x80`\0``\x84\x86\x03\x12\x15a-iW`\0\x80\xFD[\x83Q\x92P` \x84\x01Qa-{\x81a$sV[`@\x85\x01Q\x90\x92P`\x01`\x01`@\x1B\x03\x80\x82\x11\x15a-\x98W`\0\x80\xFD[\x81\x86\x01\x91P\x86`\x1F\x83\x01\x12a-\xACW`\0\x80\xFD[\x81Q\x81\x81\x11\x15a-\xBEWa-\xBEa)\x05V[`@Q`\x1F\x82\x01`\x1F\x19\x90\x81\x16`?\x01\x16\x81\x01\x90\x83\x82\x11\x81\x83\x10\x17\x15a-\xE6Wa-\xE6a)\x05V[\x81`@R\x82\x81R\x89` \x84\x87\x01\x01\x11\x15a-\xFFW`\0\x80\xFD[a.\x10\x83` \x83\x01` \x88\x01a$\xA5V[\x80\x95PPPPPP\x92P\x92P\x92V[`\x01\x81\x81[\x80\x85\x11\x15a.ZW\x81`\0\x19\x04\x82\x11\x15a.@Wa.@a+\xB0V[\x80\x85\x16\x15a.MW\x91\x81\x02\x91[\x93\x84\x1C\x93\x90\x80\x02\x90a.$V[P\x92P\x92\x90PV[`\0\x82a.qWP`\x01a\x03\xBFV[\x81a.~WP`\0a\x03\xBFV[\x81`\x01\x81\x14a.\x94W`\x02\x81\x14a.\x9EWa.\xBAV[`\x01\x91PPa\x03\xBFV[`\xFF\x84\x11\x15a.\xAFWa.\xAFa+\xB0V[PP`\x01\x82\x1Ba\x03\xBFV[P` \x83\x10a\x013\x83\x10\x16`N\x84\x10`\x0B\x84\x10\x16\x17\x15a.\xDDWP\x81\x81\na\x03\xBFV[a.\xE7\x83\x83a.\x1FV[\x80`\0\x19\x04\x82\x11\x15a.\xFBWa.\xFBa+\xB0V[\x02\x93\x92PPPV[`\0a\x17\xBF\x83\x83a.bV[` \x80\x82R`\x14\x90\x82\x01Rsslicing out of range``\x1B`@\x82\x01R``\x01\x90V\xFE\xA2dipfsX\"\x12 `\x0Ek\x17>\x10\xEA\xCE\r\x8F\xF9#\xEBa\xF7_\x1B\x0B/#\0\x0E\r\x124\xA0\x12\x90\x85\xED\xEF\x18dsolcC\0\x08\x15\x003";
     /// The bytecode of the contract.
-    pub static BASINSTORAGE_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
-        __BYTECODE,
-    );
+    pub static BASINSTORAGE_BYTECODE: ::ethers::core::types::Bytes =
+        ::ethers::core::types::Bytes::from_static(__BYTECODE);
     #[rustfmt::skip]
     const __DEPLOYED_BYTECODE: &[u8] = b"`\x80`@R4\x80\x15a\0\x10W`\0\x80\xFD[P`\x046\x10a\x01BW`\x005`\xE0\x1C\x80cW\x08\x92\xC8\x11a\0\xB8W\x80c\x89\xEC\x0B\x93\x11a\0|W\x80c\x89\xEC\x0B\x93\x14a\x03'W\x80c\x91\xD1HT\x14a\x03:W\x80c\x9F)7\x0B\x14a\x03MW\x80c\xA2\x17\xFD\xDF\x14a\x03`W\x80c\xD0oh\x02\x14a\x03hW\x80c\xD5Gt\x1F\x14a\x03{W`\0\x80\xFD[\x80cW\x08\x92\xC8\x14a\x02\x8DW\x80cY\xB6L]\x14a\x02\xA0W\x80co\nC\xC7\x14a\x02\xC0W\x80c\x82+\xA4\x0B\x14a\x02\xD3W\x80c\x87\xA4\x1B\x81\x14a\x02\xFAW`\0\x80\xFD[\x80c//\xF1]\x11a\x01\nW\x80c//\xF1]\x14a\x02\x0CW\x80c6V\x8A\xBE\x14a\x02!W\x80c<~Y\x99\x14a\x024W\x80c?\xF4!\xE9\x14a\x02TW\x80cHMZ:\x14a\x02gW\x80cR\xB6+>\x14a\x02zW`\0\x80\xFD[\x80c\x01\xFF\xC9\xA7\x14a\x01GW\x80c\x06\xA0\x9D\xEA\x14a\x01oW\x80c\x12\x1Eb\x0E\x14a\x01\x9AW\x80c$\x8A\x9C\xA3\x14a\x01\xBBW\x80c&)Jw\x14a\x01\xECW[`\0\x80\xFD[a\x01Za\x01U6`\x04a$IV[a\x03\x8EV[`@Q\x90\x15\x15\x81R` \x01[`@Q\x80\x91\x03\x90\xF3[a\x01\x82a\x01}6`\x04a$\x88V[a\x03\xC5V[`@Q`\x01`\x01`@\x1B\x03\x90\x91\x16\x81R` \x01a\x01fV[a\x01\xADa\x01\xA86`\x04a$\x88V[a\x03\xD0V[`@Qa\x01f\x92\x91\x90a$\xF5V[a\x01\xDEa\x01\xC96`\x04a%\x19V[`\0\x90\x81R` \x81\x90R`@\x90 `\x01\x01T\x90V[`@Q\x90\x81R` \x01a\x01fV[a\x01\xFFa\x01\xFA6`\x04a%NV[a\x03\xF1V[`@Qa\x01f\x91\x90a%iV[a\x02\x1Fa\x02\x1A6`\x04a%\xCBV[a\x04\xE0V[\0[a\x02\x1Fa\x02/6`\x04a%\xCBV[a\x05\nV[a\x02Ga\x02B6`\x04a$\x88V[a\x05\x8DV[`@Qa\x01f\x91\x90a%\xF7V[a\x01Za\x02b6`\x04a$\x88V[a\x05\xABV[a\x02Ga\x02u6`\x04a$\x88V[a\x05\xB6V[a\x02\x1Fa\x02\x886`\x04a&lV[a\x05\xD4V[a\x02\x1Fa\x02\x9B6`\x04a&\xBEV[a\x07\rV[a\x02\xB3a\x02\xAE6`\x04a'WV[a\t'V[`@Qa\x01f\x91\x90a'\xA7V[a\x02\xB3a\x02\xCE6`\x04a(AV[a\tuV[a\x01\xDE\x7F\xAF\xDAe\x8E\xE71\xB8\xF8b\x92\xE3\xB5*1\x154\xCD\x93d+\x12\xA6\x98\x01$91n\x0C:\t\x95\x81V[a\x03\ra\x03\x086`\x04a$\x88V[a\t\xC2V[`@\x80Q`\x07\x93\x84\x0B\x81R\x91\x90\x92\x0B` \x82\x01R\x01a\x01fV[a\x02Ga\x0356`\x04a$\x88V[a\t\xD0V[a\x01Za\x03H6`\x04a%\xCBV[a\t\xEEV[a\x03\ra\x03[6`\x04a$\x88V[a\n\x17V[a\x01\xDE`\0\x81V[a\x01\x82a\x03v6`\x04a$\x88V[a\n%V[a\x02\x1Fa\x03\x896`\x04a%\xCBV[a\n0V[`\0`\x01`\x01`\xE0\x1B\x03\x19\x82\x16cye\xDB\x0B`\xE0\x1B\x14\x80a\x03\xBFWPc\x01\xFF\xC9\xA7`\xE0\x1B`\x01`\x01`\xE0\x1B\x03\x19\x83\x16\x14[\x92\x91PPV[`\0a\x03\xBF\x82a\nUV[```\0\x80a\x03\xDE\x84a\n\x93V[\x80Q` \x90\x91\x01Q\x90\x95\x90\x94P\x92PPPV[`\x01`\x01`\xA0\x1B\x03\x81\x16`\0\x90\x81R`\x02` \x90\x81R`@\x80\x83 \x80T\x82Q\x81\x85\x02\x81\x01\x85\x01\x90\x93R\x80\x83R``\x94\x92\x93\x91\x92\x90\x91\x84\x01[\x82\x82\x10\x15a\x04\xD5W\x83\x82\x90`\0R` `\0 \x01\x80Ta\x04H\x90a(\x8CV[\x80`\x1F\x01` \x80\x91\x04\x02` \x01`@Q\x90\x81\x01`@R\x80\x92\x91\x90\x81\x81R` \x01\x82\x80Ta\x04t\x90a(\x8CV[\x80\x15a\x04\xC1W\x80`\x1F\x10a\x04\x96Wa\x01\0\x80\x83T\x04\x02\x83R\x91` \x01\x91a\x04\xC1V[\x82\x01\x91\x90`\0R` `\0 \x90[\x81T\x81R\x90`\x01\x01\x90` \x01\x80\x83\x11a\x04\xA4W\x82\x90\x03`\x1F\x16\x82\x01\x91[PPPPP\x81R` \x01\x90`\x01\x01\x90a\x04)V[PPPP\x90P\x91\x90PV[`\0\x82\x81R` \x81\x90R`@\x90 `\x01\x01Ta\x04\xFB\x81a\n\xDDV[a\x05\x05\x83\x83a\n\xEAV[PPPV[`\x01`\x01`\xA0\x1B\x03\x81\x163\x14a\x05\x7FW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`/`$\x82\x01R\x7FAccessControl: can only renounce`D\x82\x01Rn\x1097\xB62\xB9\x9037\xB9\x109\xB2\xB63`\x89\x1B`d\x82\x01R`\x84\x01[`@Q\x80\x91\x03\x90\xFD[a\x05\x89\x82\x82a\x0BnV[PPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01Ra\x03\xBF\x82a\x0B\xD3V[`\0a\x03\xBF\x82a\x0C\x1DV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01Ra\x03\xBF\x82a\x0CSV[\x7F\xAF\xDAe\x8E\xE71\xB8\xF8b\x92\xE3\xB5*1\x154\xCD\x93d+\x12\xA6\x98\x01$91n\x0C:\t\x95a\x05\xFE\x81a\n\xDDV[`\0`\x01`\x01`\xA0\x1B\x03\x16`\x01\x84\x84`@Qa\x06\x1B\x92\x91\x90a(\xC6V[\x90\x81R`@Q\x90\x81\x90\x03` \x01\x90 T`\x01`\x01`\xA0\x1B\x03\x16\x14a\x06VW\x82\x82`@Qc\\x\xF6\xED`\xE1\x1B\x81R`\x04\x01a\x05v\x92\x91\x90a(\xD6V[\x83`\x01\x84\x84`@Qa\x06i\x92\x91\x90a(\xC6V[\x90\x81R`@\x80Q` \x92\x81\x90\x03\x83\x01\x90 \x80T`\x01`\x01`\xA0\x1B\x03\x19\x16`\x01`\x01`\xA0\x1B\x03\x94\x85\x16\x17\x90U\x91\x86\x16`\0\x90\x81R`\x02\x82R\x91\x82 \x80T`\x01\x81\x01\x82U\x90\x83R\x91 \x01a\x06\xBC\x83\x85\x83a)iV[P\x83`\x01`\x01`\xA0\x1B\x03\x16\x83\x83`@Qa\x06\xD7\x92\x91\x90a(\xC6V[`@Q\x90\x81\x90\x03\x81 \x90\x7F\xF8\xDE\xBC/\x17E\xEB\xA8i\t\x89\x0F-\xC0abG\x05\xC7C)4\x88)\xE0J\xBAC\xC0\x15\xB9\xA2\x90`\0\x90\xA3PPPPV[\x7F\xAF\xDAe\x8E\xE71\xB8\xF8b\x92\xE3\xB5*1\x154\xCD\x93d+\x12\xA6\x98\x01$91n\x0C:\t\x95a\x077\x81a\n\xDDV[`\0C\x90P`\0`\x01\x87\x87`@Qa\x07P\x92\x91\x90a(\xC6V[\x90\x81R`@Q\x90\x81\x90\x03` \x01\x90 T`\x01`\x01`\xA0\x1B\x03\x16\x90P\x80a\x07\x8DW\x86\x86`@Qc\x15\xE6\xE0\xEB`\xE2\x1B\x81R`\x04\x01a\x05v\x92\x91\x90a(\xD6V[`\0[\x84\x81\x10\x15a\t\x1DW`\x04\x88\x88`@Qa\x07\xAA\x92\x91\x90a(\xC6V[\x90\x81R` \x01`@Q\x80\x91\x03\x90 `\0\x84\x81R` \x01\x90\x81R` \x01`\0 \x86\x86\x83\x81\x81\x10a\x07\xDBWa\x07\xDBa*)V[\x90P` \x02\x81\x01\x90a\x07\xED\x91\x90a*?V[\x81T`\x01\x81\x01\x83U`\0\x92\x83R` \x90\x92 \x90\x91`\x03\x02\x01a\x08\x0F\x82\x82a*\xA5V[PP`\x03\x88\x88`@Qa\x08#\x92\x91\x90a(\xC6V[\x90\x81R`@Q\x90\x81\x90\x03` \x01\x90 \x80T\x90`\0a\x08@\x83a+\xC6V[\x91\x90PUP\x81`\x01`\x01`\xA0\x1B\x03\x16\x88\x88`@Qa\x08_\x92\x91\x90a(\xC6V[`@Q\x80\x91\x03\x90 \x87\x87\x84\x81\x81\x10a\x08yWa\x08ya*)V[\x90P` \x02\x81\x01\x90a\x08\x8B\x91\x90a*?V[a\x08\x99\x90` \x81\x01\x90a$\x88V[`\x01`\x01`@\x1B\x03\x16\x7Fy\xB3\x877\xA5?\x0B\xC2.4\x83sU\xA5\xC9\xD1\xBF\xCD\xDF\x81|\xB0\x02/\x82\xFE\x93\x8B\x05\x88\xBF?\x89\x89\x86\x81\x81\x10a\x08\xD5Wa\x08\xD5a*)V[\x90P` \x02\x81\x01\x90a\x08\xE7\x91\x90a*?V[a\x08\xF5\x90`@\x81\x01\x90a*_V[`@Qa\t\x03\x92\x91\x90a(\xD6V[`@Q\x80\x91\x03\x90\xA4\x80a\t\x15\x81a+\xC6V[\x91PPa\x07\x90V[PPPPPPPPV[```\0`\x03\x86\x86`@Qa\t=\x92\x91\x90a(\xC6V[\x90\x81R` \x01`@Q\x80\x91\x03\x90 T\x90P\x80\x83\x11a\t[W\x82a\t]V[\x80[\x92Pa\tk\x86\x86\x86\x86a\x0C\x92V[\x96\x95PPPPPPV[```\0`\x03\x85\x85`@Qa\t\x8B\x92\x91\x90a(\xC6V[\x90\x81R` \x01`@Q\x80\x91\x03\x90 T\x90P\x80\x83\x11a\t\xA9W\x82a\t\xABV[\x80[\x92Pa\t\xB9\x85\x85C\x86a\x0C\x92V[\x95\x94PPPPPV[`\0\x80`\0a\x03\xDE\x84a\x0FlV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01Ra\x03\xBF\x82a\x0F\xB5V[`\0\x91\x82R` \x82\x81R`@\x80\x84 `\x01`\x01`\xA0\x1B\x03\x93\x90\x93\x16\x84R\x91\x90R\x90 T`\xFF\x16\x90V[`\0\x80`\0a\x03\xDE\x84a\x0F\xF4V[`\0a\x03\xBF\x82a\x102V[`\0\x82\x81R` \x81\x90R`@\x90 `\x01\x01Ta\nK\x81a\n\xDDV[a\x05\x05\x83\x83a\x0BnV[`\0\x80a\nj\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\n\x80`\x05c\x07\xA1\xF0Q`Q\x85a\x10\x95V[\x90Pa\n\x8B\x81a\x10\xBAV[\x94\x93PPPPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`\0a\n\xBC\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\n\xD2`\x05c\x02\xC3s\x86`Q\x85a\x10\x95V[\x90Pa\n\x8B\x81a\x10\xD1V[a\n\xE7\x813a\x11\x08V[PV[a\n\xF4\x82\x82a\t\xEEV[a\x05\x89W`\0\x82\x81R` \x81\x81R`@\x80\x83 `\x01`\x01`\xA0\x1B\x03\x85\x16\x84R\x90\x91R\x90 \x80T`\xFF\x19\x16`\x01\x17\x90Ua\x0B*3\x90V[`\x01`\x01`\xA0\x1B\x03\x16\x81`\x01`\x01`\xA0\x1B\x03\x16\x83\x7F/\x87\x88\x11~~\xFF\x1D\x82\xE9&\xECyI\x01\xD1|x\x02JP'\t@0E@\xA73eo\r`@Q`@Q\x80\x91\x03\x90\xA4PPV[a\x0Bx\x82\x82a\t\xEEV[\x15a\x05\x89W`\0\x82\x81R` \x81\x81R`@\x80\x83 `\x01`\x01`\xA0\x1B\x03\x85\x16\x80\x85R\x92R\x80\x83 \x80T`\xFF\x19\x16\x90UQ3\x92\x85\x91\x7F\xF69\x1F\\2\xD9\xC6\x9D*G\xEAg\x0BD)t\xB595\xD1\xED\xC7\xFDd\xEB!\xE0G\xA89\x17\x1B\x91\x90\xA4PPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`\0a\x0B\xFC\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0C\x12`\x05c\xB2\x05\x9CI`Q\x85a\x10\x95V[\x90Pa\n\x8B\x81a\x11aV[`\0\x80a\x0C2\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0CH`\x05c\x9C\x9A\xC8\x19`Q\x85a\x10\x95V[\x90Pa\n\x8B\x81a\x11\xC5V[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`\0a\x0C|\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0C\x12`\x05c\xFF\x88\xE8<`Q\x85a\x10\x95V[```\0\x80\x83`\x01`\x01`@\x1B\x03\x81\x11\x15a\x0C\xAFWa\x0C\xAFa)\x05V[`@Q\x90\x80\x82R\x80` \x02` \x01\x82\x01`@R\x80\x15a\r\rW\x81` \x01[a\x0C\xFA`@Q\x80``\x01`@R\x80`\0`\x01`\x01`@\x1B\x03\x16\x81R` \x01``\x81R` \x01``\x81RP\x90V[\x81R` \x01\x90`\x01\x90\x03\x90\x81a\x0C\xCDW\x90P[P\x90P\x84[\x84\x83\x10\x15a\x0F_W`\0`\x04\x89\x89`@Qa\r.\x92\x91\x90a(\xC6V[\x90\x81R`@\x80Q\x91\x82\x90\x03` \x90\x81\x01\x83 `\0\x86\x81R\x90\x82R\x82\x81 \x80T\x80\x84\x02\x86\x01\x84\x01\x90\x94R\x83\x85R\x92\x91\x84\x01[\x82\x82\x10\x15a\x0E\xCBW`\0\x84\x81R` \x90\x81\x90 `@\x80Q``\x81\x01\x90\x91R`\x03\x85\x02\x90\x91\x01\x80T`\x01`\x01`@\x1B\x03\x16\x82R`\x01\x81\x01\x80T\x92\x93\x91\x92\x91\x84\x01\x91a\r\xA8\x90a(\x8CV[\x80`\x1F\x01` \x80\x91\x04\x02` \x01`@Q\x90\x81\x01`@R\x80\x92\x91\x90\x81\x81R` \x01\x82\x80Ta\r\xD4\x90a(\x8CV[\x80\x15a\x0E!W\x80`\x1F\x10a\r\xF6Wa\x01\0\x80\x83T\x04\x02\x83R\x91` \x01\x91a\x0E!V[\x82\x01\x91\x90`\0R` `\0 \x90[\x81T\x81R\x90`\x01\x01\x90` \x01\x80\x83\x11a\x0E\x04W\x82\x90\x03`\x1F\x16\x82\x01\x91[PPPPP\x81R` \x01`\x02\x82\x01\x80Ta\x0E:\x90a(\x8CV[\x80`\x1F\x01` \x80\x91\x04\x02` \x01`@Q\x90\x81\x01`@R\x80\x92\x91\x90\x81\x81R` \x01\x82\x80Ta\x0Ef\x90a(\x8CV[\x80\x15a\x0E\xB3W\x80`\x1F\x10a\x0E\x88Wa\x01\0\x80\x83T\x04\x02\x83R\x91` \x01\x91a\x0E\xB3V[\x82\x01\x91\x90`\0R` `\0 \x90[\x81T\x81R\x90`\x01\x01\x90` \x01\x80\x83\x11a\x0E\x96W\x82\x90\x03`\x1F\x16\x82\x01\x91[PPPPP\x81RPP\x81R` \x01\x90`\x01\x01\x90a\r_V[PPPP\x90P`\0[\x81Q\x81\x10\x15a\x0F=W\x86\x85\x10\x15a\x0F=W\x81\x81\x81Q\x81\x10a\x0E\xF7Wa\x0E\xF7a*)V[` \x02` \x01\x01Q\x84\x86\x81Q\x81\x10a\x0F\x11Wa\x0F\x11a*)V[` \x02` \x01\x01\x81\x90RP\x84\x80a\x0F'\x90a+\xC6V[\x95PP\x80\x80a\x0F5\x90a+\xC6V[\x91PPa\x0E\xD4V[P\x81`\0\x03a\x0FLWPa\x0F_V[\x81a\x0FV\x81a+\xDFV[\x92PPPa\r\x12V[P\x90\x81R\x95\x94PPPPPV[`@\x80Q\x80\x82\x01\x90\x91R`\0\x80\x82R` \x82\x01R`\0a\x0F\x94\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0F\xAA`\x05c\t\xC3\x0B `Q\x85a\x10\x95V[\x90Pa\n\x8B\x81a\x11\xD3V[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`\0a\x0F\xDE\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0C\x12`\x05c\x0B\xF4lW`Q\x85a\x10\x95V[`@\x80Q\x80\x82\x01\x90\x91R`\0\x80\x82R` \x82\x01R`\0a\x10\x1C\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\x0F\xAA`\x05c\x99\x04\xF2\xFF`Q\x85a\x10\x95V[`\0\x80a\x10G\x83`\x01`\x01`@\x1B\x03\x16a\x10]V[\x90P`\0a\n\x80`\x05c7\xBC6\xDA`Q\x85a\x10\x95V[```\0a\x10s\x83`\x01`\x01`@\x1B\x03\x16a\x127V[\x90P`\0a\x10\x80\x82a\x12\x85V[\x90Pa\x10\x8C\x81\x85a\x12\xA6V[a\n\x8B\x81a\x12\xB2V[``a\x12\xFD\x80a\x10\xAF\x87\x87\x87\x87`\0`\x01c\xFF\xFF\xFF\xFF\x88\x16V[\x97\x96PPPPPPPV[`\0\x80\x80a\x10\xC8\x84\x82a\x13\xD7V[P\x94\x93PPPPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01\x81\x90R\x90a\x10\xC8\x84\x83a\x14dV[a\x11\x12\x82\x82a\t\xEEV[a\x05\x89Wa\x11\x1F\x81a\x16\x12V[a\x11*\x83` a\x16$V[`@Q` \x01a\x11;\x92\x91\x90a+\xF6V[`@\x80Q`\x1F\x19\x81\x84\x03\x01\x81R\x90\x82\x90RbF\x1B\xCD`\xE5\x1B\x82Ra\x05v\x91`\x04\x01a,kV[`@\x80Q\x80\x82\x01\x90\x91R``\x80\x82R`\0` \x83\x01\x81\x90R\x83Q\x15a\x11\x9FWa\x11\x8A\x84\x82a\x17\xC6V[\x81Q\x91\x93P\x91P\x15a\x11\x9FWa\n\x8B\x82a\x19kV[PP`@\x80Q`\0\x81\x83\x01\x81\x81R``\x83\x01\x90\x93R\x91\x81R` \x81\x01\x91\x90\x91R\x92\x91PPV[`\0\x80\x80a\x10\xC8\x84\x82a\x1A\xC7V[`@\x80Q\x80\x82\x01\x90\x91R`\0\x80\x82R` \x82\x01R`\0\x80a\x11\xF4\x84\x82a\x1BbV[\x92P\x90P`\x02\x81\x14a\x12\x08Wa\x12\x08a,~V[a\x12\x12\x84\x83a\x1B\xD5V[`\x07\x91\x90\x91\x0B\x84R\x91Pa\x12&\x84\x83a\x1B\xD5V[P`\x07\x0B` \x84\x01RP\x90\x92\x91PPV[`\0`\x17\x82\x11a\x12IWP`\x01\x91\x90PV[`\xFF\x82\x11a\x12YWP`\x02\x91\x90PV[a\xFF\xFF\x82\x11a\x12jWP`\x03\x91\x90PV[c\xFF\xFF\xFF\xFF\x82\x11a\x12}WP`\x05\x91\x90PV[P`\t\x91\x90PV[a\x12\x8Da$\x14V[\x80Qa\x12\x99\x90\x83a\x1B\xEFV[P`\0` \x82\x01R\x91\x90PV[a\x05\x89\x82`\0\x83a\x1CfV[``\x81` \x01Q`\0\x14a\x12\xF7W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0C`$\x82\x01Rk$\xB7;0\xB64\xB2\x10!\xA1'\xA9`\xA1\x1B`D\x82\x01R`d\x01a\x05vV[PQQ\x90V[``a\x13\x10`\x05`\x7F`\x99\x1B\x01\x84a\x1D\x85V[`\0\x80`\x05`\x7F`\x99\x1B\x01\x88\x86\x86a\x13)W`\0a\x13,V[`\x01[\x8A\x8A\x8E`@Q` \x01a\x13D\x96\x95\x94\x93\x92\x91\x90a,\x94V[`@\x80Q`\x1F\x19\x81\x84\x03\x01\x81R\x90\x82\x90Ra\x13^\x91a,\xE3V[`\0`@Q\x80\x83\x03\x81\x85Z\xF4\x91PP=\x80`\0\x81\x14a\x13\x99W`@Q\x91P`\x1F\x19`?=\x01\x16\x82\x01`@R=\x82R=`\0` \x84\x01>a\x13\x9EV[``\x91P[P\x91P\x91P\x81a\x13\xC1W`@Qc\x8A}\xB5\xBF`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[a\x13\xCA\x81a\x1D\xD3V[\x99\x98PPPPPPPPPV[`\0\x80`\0\x80a\x13\xE7\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16\x15a\x14VW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7Finvalid maj (expected MajUnsigne`D\x82\x01RddInt)`\xD8\x1B`d\x82\x01R`\x84\x01a\x05vV[\x92P\x83\x91PP[\x92P\x92\x90PV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R`\0\x80`\0a\x14\x88\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x02\x14\x80a\x14\xADWP`\xFF\x82\x16`\x03\x14[a\x15\x17W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7Finvalid maj (expected MajByteStr`D\x82\x01Rting or MajTextString)`X\x1B`d\x82\x01R`\x84\x01a\x05vV[`\0a\x15#\x82\x87a,\xF5V[\x90P`\0\x82`\x01`\x01`@\x1B\x03\x81\x11\x15a\x15?Wa\x15?a)\x05V[`@Q\x90\x80\x82R\x80`\x1F\x01`\x1F\x19\x16` \x01\x82\x01`@R\x80\x15a\x15iW` \x82\x01\x81\x806\x837\x01\x90P[P\x90P`\0\x87[\x83\x81\x10\x15a\x15\xDEW\x89\x81\x81Q\x81\x10a\x15\x8AWa\x15\x8Aa*)V[` \x01\x01Q`\xF8\x1C`\xF8\x1B\x83\x83\x81Q\x81\x10a\x15\xA7Wa\x15\xA7a*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP\x81a\x15\xC8\x81a+\xC6V[\x92PP\x80\x80a\x15\xD6\x90a+\xC6V[\x91PPa\x15pV[P`@\x80Q\x80\x82\x01\x90\x91R\x82\x81R`\xFF\x86\x16`\x03\x14` \x82\x01Ra\x16\x02\x85\x8Aa,\xF5V[\x96P\x96PPPPPP\x92P\x92\x90PV[``a\x03\xBF`\x01`\x01`\xA0\x1B\x03\x83\x16`\x14[```\0a\x163\x83`\x02a-\x08V[a\x16>\x90`\x02a,\xF5V[`\x01`\x01`@\x1B\x03\x81\x11\x15a\x16UWa\x16Ua)\x05V[`@Q\x90\x80\x82R\x80`\x1F\x01`\x1F\x19\x16` \x01\x82\x01`@R\x80\x15a\x16\x7FW` \x82\x01\x81\x806\x837\x01\x90P[P\x90P`\x03`\xFC\x1B\x81`\0\x81Q\x81\x10a\x16\x9AWa\x16\x9Aa*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP`\x0F`\xFB\x1B\x81`\x01\x81Q\x81\x10a\x16\xC9Wa\x16\xC9a*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP`\0a\x16\xED\x84`\x02a-\x08V[a\x16\xF8\x90`\x01a,\xF5V[\x90P[`\x01\x81\x11\x15a\x17pWo\x18\x18\x99\x19\x9A\x1A\x9B\x1B\x9C\x1C\xB0\xB11\xB22\xB3`\x81\x1B\x85`\x0F\x16`\x10\x81\x10a\x17,Wa\x17,a*)V[\x1A`\xF8\x1B\x82\x82\x81Q\x81\x10a\x17BWa\x17Ba*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP`\x04\x94\x90\x94\x1C\x93a\x17i\x81a+\xDFV[\x90Pa\x16\xFBV[P\x83\x15a\x17\xBFW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01\x81\x90R`$\x82\x01R\x7FStrings: hex length insufficient`D\x82\x01R`d\x01a\x05vV[\x93\x92PPPV[```\0\x80`\0a\x17\xD7\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x06\x14\x80a\x17\xFCWP`\xFF\x82\x16`\x02\x14[a\x18_W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`.`$\x82\x01R\x7Finvalid maj (expected MajTag or `D\x82\x01RmMajByteString)`\x90\x1B`d\x82\x01R`\x84\x01a\x05vV[`\x05\x19`\xFF\x83\x16\x01a\x18\x98Wa\x18u\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x02\x14a\x18\x98Wa\x18\x98a,~V[`\0a\x18\xA4\x82\x87a,\xF5V[\x90P`\0\x82`\x01`\x01`@\x1B\x03\x81\x11\x15a\x18\xC0Wa\x18\xC0a)\x05V[`@Q\x90\x80\x82R\x80`\x1F\x01`\x1F\x19\x16` \x01\x82\x01`@R\x80\x15a\x18\xEAW` \x82\x01\x81\x806\x837\x01\x90P[P\x90P`\0\x87[\x83\x81\x10\x15a\x19_W\x89\x81\x81Q\x81\x10a\x19\x0BWa\x19\x0Ba*)V[` \x01\x01Q`\xF8\x1C`\xF8\x1B\x83\x83\x81Q\x81\x10a\x19(Wa\x19(a*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP\x81a\x19I\x81a+\xC6V[\x92PP\x80\x80a\x19W\x90a+\xC6V[\x91PPa\x18\xF1V[P\x81a\x16\x02\x85\x8Aa,\xF5V[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R\x81Q`\0\x03a\x19\xB4WPP`@\x80Q`\x80\x81\x01\x82R`\x01\x91\x81\x01\x91\x82R`\0``\x82\x01\x81\x90R\x91\x81R` \x81\x01\x91\x90\x91R\x90V[`\0`\x01\x83Qa\x19\xC4\x91\x90a-\x1FV[`\x01`\x01`@\x1B\x03\x81\x11\x15a\x19\xDBWa\x19\xDBa)\x05V[`@Q\x90\x80\x82R\x80`\x1F\x01`\x1F\x19\x16` \x01\x82\x01`@R\x80\x15a\x1A\x05W` \x82\x01\x81\x806\x837\x01\x90P[P\x90P`\0\x83`\0\x81Q\x81\x10a\x1A\x1DWa\x1A\x1Da*)V[\x01` \x01Q`\x01`\x01`\xF8\x1B\x03\x19\x16`\x01`\xF8\x1B\x03a\x1A:WP`\x01[`\x01[\x84Q\x81\x10\x15a\x1A\xACW\x84\x81\x81Q\x81\x10a\x1AXWa\x1AXa*)V[\x01` \x01Q`\x01`\x01`\xF8\x1B\x03\x19\x16\x83a\x1As`\x01\x84a-\x1FV[\x81Q\x81\x10a\x1A\x83Wa\x1A\x83a*)V[` \x01\x01\x90`\x01`\x01`\xF8\x1B\x03\x19\x16\x90\x81`\0\x1A\x90SP\x80a\x1A\xA4\x81a+\xC6V[\x91PPa\x1A=V[P`@\x80Q\x80\x82\x01\x90\x91R\x91\x82R\x15\x15` \x82\x01R\x92\x91PPV[`\0\x80`\0\x80a\x1A\xD7\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x07\x14a\x1B:W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x1F`$\x82\x01R\x7Finvalid maj (expected MajOther)\0`D\x82\x01R`d\x01a\x05vV[`\x15\x81\x14\x80a\x1BIWP`\x14\x81\x14[a\x1BUWa\x1BUa,~V[`\x14\x14\x15\x95\x93\x94PPPPV[`\0\x80`\0\x80a\x1Br\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x04\x14a\x14VW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x1F`$\x82\x01R\x7Finvalid maj (expected MajArray)\0`D\x82\x01R`d\x01a\x05vV[`\0\x80\x80a\x1B\xE3\x85\x85a \x90V[\x90\x96\x90\x95P\x93PPPPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01Ra\x1C\x0F` \x83a-2V[\x15a\x1C7Wa\x1C\x1F` \x83a-2V[a\x1C*\x90` a-\x1FV[a\x1C4\x90\x83a,\xF5V[\x91P[` \x80\x84\x01\x83\x90R`@Q\x80\x85R`\0\x81R\x90\x81\x84\x01\x01\x81\x81\x10\x15a\x1C[W`\0\x80\xFD[`@RP\x91\x92\x91PPV[`\x17\x81`\x01`\x01`@\x1B\x03\x16\x11a\x1C\x92W\x82Qa\x1C\x8C\x90`\xE0`\x05\x85\x90\x1B\x16\x83\x17a!-V[PPPPV[`\xFF\x81`\x01`\x01`@\x1B\x03\x16\x11a\x1C\xD2W\x82Qa\x1C\xBA\x90`\x18a\x1F\xE0`\x05\x86\x90\x1B\x16\x17a!-V[P\x82Qa\x1C\x8C\x90`\x01`\x01`@\x1B\x03\x83\x16`\x01a!\x96V[a\xFF\xFF\x81`\x01`\x01`@\x1B\x03\x16\x11a\x1D\x13W\x82Qa\x1C\xFB\x90`\x19a\x1F\xE0`\x05\x86\x90\x1B\x16\x17a!-V[P\x82Qa\x1C\x8C\x90`\x01`\x01`@\x1B\x03\x83\x16`\x02a!\x96V[c\xFF\xFF\xFF\xFF\x81`\x01`\x01`@\x1B\x03\x16\x11a\x1DVW\x82Qa\x1D>\x90`\x1Aa\x1F\xE0`\x05\x86\x90\x1B\x16\x17a!-V[P\x82Qa\x1C\x8C\x90`\x01`\x01`@\x1B\x03\x83\x16`\x04a!\x96V[\x82Qa\x1Dm\x90`\x1Ba\x1F\xE0`\x05\x86\x90\x1B\x16\x17a!-V[P\x82Qa\x1C\x8C\x90`\x01`\x01`@\x1B\x03\x83\x16`\x08a!\x96V[G\x81\x81\x10\x15a\x1D\xB1W`@QcG\x87\xA1\x03`\xE1\x1B\x81R`\x04\x81\x01\x82\x90R`$\x81\x01\x83\x90R`D\x01a\x05vV[\x82?\x15\x15\x80a\x1C\x8CW`@Qc\x06M\x95K`\xE4\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[```\0\x80`\0\x84\x80` \x01\x90Q\x81\x01\x90a\x1D\xEE\x91\x90a-TV[\x91\x94P\x92P\x90P`\x01`\x01`@\x1B\x03\x82\x16a\x1E(W\x80Q\x15a\x1E#W`@Qc\x0Et\x99\x07`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[a\x1E\x94V[`\x01`\x01`@\x1B\x03\x82\x16`Q\x14\x80a\x1EIWP`\x01`\x01`@\x1B\x03\x82\x16`q\x14[\x15a\x1EpW\x80Q`\0\x03a\x1E#W`@Qc\x0Et\x99\x07`\xE0\x1B\x81R`\x04\x01`@Q\x80\x91\x03\x90\xFD[`@Qc\xF1\xF6\xBC\xED`\xE0\x1B\x81R`\x01`\x01`@\x1B\x03\x83\x16`\x04\x82\x01R`$\x01a\x05vV[\x82\x15a\n\x8BW`@Qc\xD4\xBBfq`\xE0\x1B\x81R`\x04\x81\x01\x84\x90R`$\x01a\x05vV[`\0\x80`\0\x80a\x1E\xC6\x86\x86a\"\x1BV[\x90Pa\x1E\xD3`\x01\x86a,\xF5V[\x94P`\x07`\x05\x82\x90\x1C\x16`\x1F\x82\x16`\x1C\x81\x10a\x1F?W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`%`$\x82\x01R\x7Fcannot handle headers with extra`D\x82\x01Rd > 27`\xD8\x1B`d\x82\x01R`\x84\x01a\x05vV[`\x18\x81`\xFF\x16\x10\x15a\x1F]W\x90\x94P`\xFF\x16\x92P\x84\x91Pa \x89\x90PV[\x80`\xFF\x16`\x18\x03a\x1F\xD9W`\0a\x1Ft\x89\x89a\"\x1BV[\x90Pa\x1F\x81`\x01\x89a,\xF5V[\x97P`\x18\x81`\xFF\x16\x10\x15a\x1F\xC6W`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`\x0C`$\x82\x01Rk4\xB7;0\xB64\xB2\x101\xB17\xB9`\xA1\x1B`D\x82\x01R`d\x01a\x05vV[\x91\x95PP`\xFF\x16\x92P\x84\x91Pa \x89\x90PV[\x80`\xFF\x16`\x19\x03a \x13W`\0a\x1F\xF0\x89\x89a\"jV[\x90Pa\x1F\xFD`\x02\x89a,\xF5V[\x97P\x91\x95PPa\xFF\xFF\x16\x92P\x84\x91Pa \x89\x90PV[\x80`\xFF\x16`\x1A\x03a OW`\0a *\x89\x89a\"\xA3V[\x90Pa 7`\x04\x89a,\xF5V[\x97P\x91\x95PPc\xFF\xFF\xFF\xFF\x16\x92P\x84\x91Pa \x89\x90PV[\x80`\xFF\x16`\x1B\x14a bWa ba,~V[`\0a n\x89\x89a\"\xDCV[\x90Pa {`\x08\x89a,\xF5V[\x97P\x91\x95P\x90\x93P\x85\x92PPP[\x92P\x92P\x92V[`\0\x80`\0\x80a \xA0\x86\x86a\x1E\xB6V[\x96P\x90\x92P`\x01`\x01`@\x1B\x03\x16\x90P`\xFF\x82\x16`\x01\x14\x80a \xC3WP`\xFF\x82\x16\x15[a\x14VW`@QbF\x1B\xCD`\xE5\x1B\x81R` `\x04\x82\x01R`5`$\x82\x01R\x7Finvalid maj (expected MajSignedI`D\x82\x01Rtnt or MajUnsignedInt)`X\x1B`d\x82\x01R`\x84\x01a\x05vV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R\x82QQ`\0a!R\x82`\x01a,\xF5V[\x90P\x84` \x01Q\x82\x10a!sWa!s\x85a!n\x83`\x02a-\x08V[a#\x15V[\x84Q` \x83\x82\x01\x01\x85\x81SP\x80Q\x82\x11\x15a!\x8CW\x81\x81R[P\x93\x94\x93PPPPV[`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R\x83QQ`\0a!\xBA\x82\x85a,\xF5V[\x90P\x85` \x01Q\x81\x11\x15a!\xD7Wa!\xD7\x86a!n\x83`\x02a-\x08V[`\0`\x01a!\xE7\x86a\x01\0a/\x03V[a!\xF1\x91\x90a-\x1FV[\x90P\x86Q\x82\x81\x01\x87\x83\x19\x82Q\x16\x17\x81RP\x80Q\x83\x11\x15a\"\x0FW\x82\x81R[P\x95\x96\x95PPPPPPV[`\0a\"(\x82`\x01a,\xF5V[\x83Q\x10\x15a\"HW`@QbF\x1B\xCD`\xE5\x1B\x81R`\x04\x01a\x05v\x90a/\x0FV[\x82\x82\x81Q\x81\x10a\"ZWa\"Za*)V[\x01` \x01Q`\xF8\x1C\x90P\x92\x91PPV[`\0a\"w\x82`\x02a,\xF5V[\x83Q\x10\x15a\"\x97W`@QbF\x1B\xCD`\xE5\x1B\x81R`\x04\x01a\x05v\x90a/\x0FV[P\x01` \x01Q`\xF0\x1C\x90V[`\0a\"\xB0\x82`\x04a,\xF5V[\x83Q\x10\x15a\"\xD0W`@QbF\x1B\xCD`\xE5\x1B\x81R`\x04\x01a\x05v\x90a/\x0FV[P\x01` \x01Q`\xE0\x1C\x90V[`\0a\"\xE9\x82`\x08a,\xF5V[\x83Q\x10\x15a#\tW`@QbF\x1B\xCD`\xE5\x1B\x81R`\x04\x01a\x05v\x90a/\x0FV[P\x01` \x01Q`\xC0\x1C\x90V[\x81Qa#!\x83\x83a\x1B\xEFV[Pa\x1C\x8C\x83\x82`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01Ra\x17\xBF\x83\x83\x84Q`@\x80Q\x80\x82\x01\x90\x91R``\x81R`\0` \x82\x01R\x82Q\x82\x11\x15a#fW`\0\x80\xFD[\x83QQ`\0a#u\x84\x83a,\xF5V[\x90P\x85` \x01Q\x81\x11\x15a#\x92Wa#\x92\x86a!n\x83`\x02a-\x08V[\x85Q\x80Q\x83\x82\x01` \x01\x91`\0\x91\x80\x85\x11\x15a#\xACW\x84\x82R[PPP` \x86\x01[` \x86\x10a#\xECW\x80Q\x82Ra#\xCB` \x83a,\xF5V[\x91Pa#\xD8` \x82a,\xF5V[\x90Pa#\xE5` \x87a-\x1FV[\x95Pa#\xB4V[Q\x81Q`\0\x19` \x88\x90\x03a\x01\0\n\x01\x90\x81\x16\x90\x19\x91\x90\x91\x16\x17\x90RP\x84\x91PP\x93\x92PPPV[`@Q\x80`@\x01`@R\x80a$<`@Q\x80`@\x01`@R\x80``\x81R` \x01`\0\x81RP\x90V[\x81R` \x01`\0\x81RP\x90V[`\0` \x82\x84\x03\x12\x15a$[W`\0\x80\xFD[\x815`\x01`\x01`\xE0\x1B\x03\x19\x81\x16\x81\x14a\x17\xBFW`\0\x80\xFD[`\x01`\x01`@\x1B\x03\x81\x16\x81\x14a\n\xE7W`\0\x80\xFD[`\0` \x82\x84\x03\x12\x15a$\x9AW`\0\x80\xFD[\x815a\x17\xBF\x81a$sV[`\0[\x83\x81\x10\x15a$\xC0W\x81\x81\x01Q\x83\x82\x01R` \x01a$\xA8V[PP`\0\x91\x01RV[`\0\x81Q\x80\x84Ra$\xE1\x81` \x86\x01` \x86\x01a$\xA5V[`\x1F\x01`\x1F\x19\x16\x92\x90\x92\x01` \x01\x92\x91PPV[`@\x81R`\0a%\x08`@\x83\x01\x85a$\xC9V[\x90P\x82\x15\x15` \x83\x01R\x93\x92PPPV[`\0` \x82\x84\x03\x12\x15a%+W`\0\x80\xFD[P5\x91\x90PV[\x805`\x01`\x01`\xA0\x1B\x03\x81\x16\x81\x14a%IW`\0\x80\xFD[\x91\x90PV[`\0` \x82\x84\x03\x12\x15a%`W`\0\x80\xFD[a\x17\xBF\x82a%2V[`\0` \x80\x83\x01\x81\x84R\x80\x85Q\x80\x83R`@\x86\x01\x91P`@\x81`\x05\x1B\x87\x01\x01\x92P\x83\x87\x01`\0[\x82\x81\x10\x15a%\xBEW`?\x19\x88\x86\x03\x01\x84Ra%\xAC\x85\x83Qa$\xC9V[\x94P\x92\x85\x01\x92\x90\x85\x01\x90`\x01\x01a%\x90V[P\x92\x97\x96PPPPPPPV[`\0\x80`@\x83\x85\x03\x12\x15a%\xDEW`\0\x80\xFD[\x825\x91Pa%\xEE` \x84\x01a%2V[\x90P\x92P\x92\x90PV[` \x81R`\0\x82Q`@` \x84\x01Ra&\x13``\x84\x01\x82a$\xC9V[\x90P` \x84\x01Q\x15\x15`@\x84\x01R\x80\x91PP\x92\x91PPV[`\0\x80\x83`\x1F\x84\x01\x12a&=W`\0\x80\xFD[P\x815`\x01`\x01`@\x1B\x03\x81\x11\x15a&TW`\0\x80\xFD[` \x83\x01\x91P\x83` \x82\x85\x01\x01\x11\x15a\x14]W`\0\x80\xFD[`\0\x80`\0`@\x84\x86\x03\x12\x15a&\x81W`\0\x80\xFD[a&\x8A\x84a%2V[\x92P` \x84\x015`\x01`\x01`@\x1B\x03\x81\x11\x15a&\xA5W`\0\x80\xFD[a&\xB1\x86\x82\x87\x01a&+V[\x94\x97\x90\x96P\x93\x94PPPPV[`\0\x80`\0\x80`@\x85\x87\x03\x12\x15a&\xD4W`\0\x80\xFD[\x845`\x01`\x01`@\x1B\x03\x80\x82\x11\x15a&\xEBW`\0\x80\xFD[a&\xF7\x88\x83\x89\x01a&+V[\x90\x96P\x94P` \x87\x015\x91P\x80\x82\x11\x15a'\x10W`\0\x80\xFD[\x81\x87\x01\x91P\x87`\x1F\x83\x01\x12a'$W`\0\x80\xFD[\x815\x81\x81\x11\x15a'3W`\0\x80\xFD[\x88` \x82`\x05\x1B\x85\x01\x01\x11\x15a'HW`\0\x80\xFD[\x95\x98\x94\x97PP` \x01\x94PPPV[`\0\x80`\0\x80``\x85\x87\x03\x12\x15a'mW`\0\x80\xFD[\x845`\x01`\x01`@\x1B\x03\x81\x11\x15a'\x83W`\0\x80\xFD[a'\x8F\x87\x82\x88\x01a&+V[\x90\x98\x90\x97P` \x87\x015\x96`@\x015\x95P\x93PPPPV[`\0` \x80\x83\x01\x81\x84R\x80\x85Q\x80\x83R`@\x92P\x82\x86\x01\x91P\x82\x81`\x05\x1B\x87\x01\x01\x84\x88\x01`\0[\x83\x81\x10\x15a(3W`?\x19\x89\x84\x03\x01\x85R\x81Q```\x01`\x01`@\x1B\x03\x82Q\x16\x85R\x88\x82\x01Q\x81\x8A\x87\x01Ra(\x05\x82\x87\x01\x82a$\xC9V[\x91PP\x87\x82\x01Q\x91P\x84\x81\x03\x88\x86\x01Ra(\x1F\x81\x83a$\xC9V[\x96\x89\x01\x96\x94PPP\x90\x86\x01\x90`\x01\x01a'\xCEV[P\x90\x98\x97PPPPPPPPV[`\0\x80`\0`@\x84\x86\x03\x12\x15a(VW`\0\x80\xFD[\x835`\x01`\x01`@\x1B\x03\x81\x11\x15a(lW`\0\x80\xFD[a(x\x86\x82\x87\x01a&+V[\x90\x97\x90\x96P` \x95\x90\x95\x015\x94\x93PPPPV[`\x01\x81\x81\x1C\x90\x82\x16\x80a(\xA0W`\x7F\x82\x16\x91P[` \x82\x10\x81\x03a(\xC0WcNH{q`\xE0\x1B`\0R`\"`\x04R`$`\0\xFD[P\x91\x90PV[\x81\x83\x827`\0\x91\x01\x90\x81R\x91\x90PV[` \x81R\x81` \x82\x01R\x81\x83`@\x83\x017`\0\x81\x83\x01`@\x90\x81\x01\x91\x90\x91R`\x1F\x90\x92\x01`\x1F\x19\x16\x01\x01\x91\x90PV[cNH{q`\xE0\x1B`\0R`A`\x04R`$`\0\xFD[`\x1F\x82\x11\x15a\x05\x05W`\0\x81\x81R` \x81 `\x1F\x85\x01`\x05\x1C\x81\x01` \x86\x10\x15a)BWP\x80[`\x1F\x85\x01`\x05\x1C\x82\x01\x91P[\x81\x81\x10\x15a)aW\x82\x81U`\x01\x01a)NV[PPPPPPV[`\x01`\x01`@\x1B\x03\x83\x11\x15a)\x80Wa)\x80a)\x05V[a)\x94\x83a)\x8E\x83Ta(\x8CV[\x83a)\x1BV[`\0`\x1F\x84\x11`\x01\x81\x14a)\xC8W`\0\x85\x15a)\xB0WP\x83\x82\x015[`\0\x19`\x03\x87\x90\x1B\x1C\x19\x16`\x01\x86\x90\x1B\x17\x83Ua*\"V[`\0\x83\x81R` \x90 `\x1F\x19\x86\x16\x90\x83[\x82\x81\x10\x15a)\xF9W\x86\x85\x015\x82U` \x94\x85\x01\x94`\x01\x90\x92\x01\x91\x01a)\xD9V[P\x86\x82\x10\x15a*\x16W`\0\x19`\xF8\x88`\x03\x1B\x16\x1C\x19\x84\x87\x015\x16\x81U[PP`\x01\x85`\x01\x1B\x01\x83U[PPPPPV[cNH{q`\xE0\x1B`\0R`2`\x04R`$`\0\xFD[`\0\x825`^\x19\x836\x03\x01\x81\x12a*UW`\0\x80\xFD[\x91\x90\x91\x01\x92\x91PPV[`\0\x80\x835`\x1E\x19\x846\x03\x01\x81\x12a*vW`\0\x80\xFD[\x83\x01\x805\x91P`\x01`\x01`@\x1B\x03\x82\x11\x15a*\x90W`\0\x80\xFD[` \x01\x91P6\x81\x90\x03\x82\x13\x15a\x14]W`\0\x80\xFD[\x815a*\xB0\x81a$sV[\x81Tg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x19\x16`\x01`\x01`@\x1B\x03\x91\x82\x16\x17\x82U`\x01\x90\x81\x83\x01` a*\xDF\x86\x82\x01\x87a*_V[\x84\x81\x11\x15a*\xEFWa*\xEFa)\x05V[a+\x03\x81a*\xFD\x86Ta(\x8CV[\x86a)\x1BV[`\0\x94P`\x1F\x81\x11`\x01\x81\x14a+9W`\0\x82\x15a+!WP\x82\x86\x015[`\0\x19`\x03\x84\x90\x1B\x1C\x19\x16`\x01\x83\x90\x1B\x17\x85Ua+\x8EV[`\0\x85\x81R` \x90 `\x1F\x19\x83\x16\x90\x87[\x82\x81\x10\x15a+gW\x85\x89\x015\x82U\x97\x86\x01\x97\x90\x89\x01\x90\x86\x01a+JV[P\x83\x82\x10\x15a+\x84W`\0\x19`\xF8\x85`\x03\x1B\x16\x1C\x19\x88\x86\x015\x16\x81U[PP\x86\x82\x88\x1B\x01\x85U[PPPPPPPa+\xA2`@\x83\x01\x83a*_V[a\x1C\x8C\x81\x83`\x02\x86\x01a)iV[cNH{q`\xE0\x1B`\0R`\x11`\x04R`$`\0\xFD[`\0`\x01\x82\x01a+\xD8Wa+\xD8a+\xB0V[P`\x01\x01\x90V[`\0\x81a+\xEEWa+\xEEa+\xB0V[P`\0\x19\x01\x90V[\x7FAccessControl: account \0\0\0\0\0\0\0\0\0\x81R`\0\x83Qa,.\x81`\x17\x85\x01` \x88\x01a$\xA5V[p\x01\x03K\x99\x03kK\x9B\x9BKs9\x03\x93{c)`}\x1B`\x17\x91\x84\x01\x91\x82\x01R\x83Qa,_\x81`(\x84\x01` \x88\x01a$\xA5V[\x01`(\x01\x94\x93PPPPV[` \x81R`\0a\x17\xBF` \x83\x01\x84a$\xC9V[cNH{q`\xE0\x1B`\0R`\x01`\x04R`$`\0\xFD[`\0`\x01`\x01`@\x1B\x03\x80\x89\x16\x83R\x87` \x84\x01R\x80\x87\x16`@\x84\x01R\x80\x86\x16``\x84\x01R`\xC0`\x80\x84\x01Ra,\xCD`\xC0\x84\x01\x86a$\xC9V[\x91P\x80\x84\x16`\xA0\x84\x01RP\x97\x96PPPPPPPV[`\0\x82Qa*U\x81\x84` \x87\x01a$\xA5V[\x80\x82\x01\x80\x82\x11\x15a\x03\xBFWa\x03\xBFa+\xB0V[\x80\x82\x02\x81\x15\x82\x82\x04\x84\x14\x17a\x03\xBFWa\x03\xBFa+\xB0V[\x81\x81\x03\x81\x81\x11\x15a\x03\xBFWa\x03\xBFa+\xB0V[`\0\x82a-OWcNH{q`\xE0\x1B`\0R`\x12`\x04R`$`\0\xFD[P\x06\x90V[`\0\x80`\0``\x84\x86\x03\x12\x15a-iW`\0\x80\xFD[\x83Q\x92P` \x84\x01Qa-{\x81a$sV[`@\x85\x01Q\x90\x92P`\x01`\x01`@\x1B\x03\x80\x82\x11\x15a-\x98W`\0\x80\xFD[\x81\x86\x01\x91P\x86`\x1F\x83\x01\x12a-\xACW`\0\x80\xFD[\x81Q\x81\x81\x11\x15a-\xBEWa-\xBEa)\x05V[`@Q`\x1F\x82\x01`\x1F\x19\x90\x81\x16`?\x01\x16\x81\x01\x90\x83\x82\x11\x81\x83\x10\x17\x15a-\xE6Wa-\xE6a)\x05V[\x81`@R\x82\x81R\x89` \x84\x87\x01\x01\x11\x15a-\xFFW`\0\x80\xFD[a.\x10\x83` \x83\x01` \x88\x01a$\xA5V[\x80\x95PPPPPP\x92P\x92P\x92V[`\x01\x81\x81[\x80\x85\x11\x15a.ZW\x81`\0\x19\x04\x82\x11\x15a.@Wa.@a+\xB0V[\x80\x85\x16\x15a.MW\x91\x81\x02\x91[\x93\x84\x1C\x93\x90\x80\x02\x90a.$V[P\x92P\x92\x90PV[`\0\x82a.qWP`\x01a\x03\xBFV[\x81a.~WP`\0a\x03\xBFV[\x81`\x01\x81\x14a.\x94W`\x02\x81\x14a.\x9EWa.\xBAV[`\x01\x91PPa\x03\xBFV[`\xFF\x84\x11\x15a.\xAFWa.\xAFa+\xB0V[PP`\x01\x82\x1Ba\x03\xBFV[P` \x83\x10a\x013\x83\x10\x16`N\x84\x10`\x0B\x84\x10\x16\x17\x15a.\xDDWP\x81\x81\na\x03\xBFV[a.\xE7\x83\x83a.\x1FV[\x80`\0\x19\x04\x82\x11\x15a.\xFBWa.\xFBa+\xB0V[\x02\x93\x92PPPV[`\0a\x17\xBF\x83\x83a.bV[` \x80\x82R`\x14\x90\x82\x01Rsslicing out of range``\x1B`@\x82\x01R``\x01\x90V\xFE\xA2dipfsX\"\x12 `\x0Ek\x17>\x10\xEA\xCE\r\x8F\xF9#\xEBa\xF7_\x1B\x0B/#\0\x0E\r\x124\xA0\x12\x90\x85\xED\xEF\x18dsolcC\0\x08\x15\x003";
     /// The deployed bytecode of the contract.
-    pub static BASINSTORAGE_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes = ::ethers::core::types::Bytes::from_static(
-        __DEPLOYED_BYTECODE,
-    );
+    pub static BASINSTORAGE_DEPLOYED_BYTECODE: ::ethers::core::types::Bytes =
+        ::ethers::core::types::Bytes::from_static(__DEPLOYED_BYTECODE);
     pub struct BasinStorage<M>(::ethers::contract::Contract<M>);
     impl<M> ::core::clone::Clone for BasinStorage<M> {
         fn clone(&self) -> Self {
@@ -1094,13 +885,11 @@ pub mod basin_storage {
             address: T,
             client: ::std::sync::Arc<M>,
         ) -> Self {
-            Self(
-                ::ethers::contract::Contract::new(
-                    address.into(),
-                    BASINSTORAGE_ABI.clone(),
-                    client,
-                ),
-            )
+            Self(::ethers::contract::Contract::new(
+                address.into(),
+                BASINSTORAGE_ABI.clone(),
+                client,
+            ))
         }
         /// Constructs the general purpose `Deployer` instance based on the provided constructor arguments and sends it.
         /// Returns a new instance of a deployer that returns an instance of this contract after sending the transaction
@@ -1150,9 +939,7 @@ pub mod basin_storage {
                 .expect("method not found (this should never happen)")
         }
         ///Calls the contract's `PUB_ADMIN_ROLE` (0x822ba40b) function
-        pub fn pub_admin_role(
-            &self,
-        ) -> ::ethers::contract::builders::ContractCall<M, [u8; 32]> {
+        pub fn pub_admin_role(&self) -> ::ethers::contract::builders::ContractCall<M, [u8; 32]> {
             self.0
                 .method_hash([130, 43, 164, 11], ())
                 .expect("method not found (this should never happen)")
@@ -1208,10 +995,8 @@ pub mod basin_storage {
         pub fn deal_label(
             &self,
             deal_id: u64,
-        ) -> ::ethers::contract::builders::ContractCall<
-            M,
-            (::ethers::core::types::Bytes, bool),
-        > {
+        ) -> ::ethers::contract::builders::ContractCall<M, (::ethers::core::types::Bytes, bool)>
+        {
             self.0
                 .method_hash([18, 30, 98, 14], deal_id)
                 .expect("method not found (this should never happen)")
@@ -1315,10 +1100,8 @@ pub mod basin_storage {
         pub fn pubs_of_owner(
             &self,
             owner: ::ethers::core::types::Address,
-        ) -> ::ethers::contract::builders::ContractCall<
-            M,
-            ::std::vec::Vec<::std::string::String>,
-        > {
+        ) -> ::ethers::contract::builders::ContractCall<M, ::std::vec::Vec<::std::string::String>>
+        {
             self.0
                 .method_hash([38, 41, 74, 119], owner)
                 .expect("method not found (this should never happen)")
@@ -1355,66 +1138,46 @@ pub mod basin_storage {
         ///Gets the contract's `DealAdded` event
         pub fn deal_added_filter(
             &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            DealAddedFilter,
-        > {
+        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, DealAddedFilter> {
             self.0.event()
         }
         ///Gets the contract's `PubCreated` event
         pub fn pub_created_filter(
             &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            PubCreatedFilter,
-        > {
+        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, PubCreatedFilter> {
             self.0.event()
         }
         ///Gets the contract's `RoleAdminChanged` event
         pub fn role_admin_changed_filter(
             &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            RoleAdminChangedFilter,
-        > {
+        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, RoleAdminChangedFilter>
+        {
             self.0.event()
         }
         ///Gets the contract's `RoleGranted` event
         pub fn role_granted_filter(
             &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            RoleGrantedFilter,
-        > {
+        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, RoleGrantedFilter>
+        {
             self.0.event()
         }
         ///Gets the contract's `RoleRevoked` event
         pub fn role_revoked_filter(
             &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            RoleRevokedFilter,
-        > {
+        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, RoleRevokedFilter>
+        {
             self.0.event()
         }
         /// Returns an `Event` builder for all the events of this contract.
         pub fn events(
             &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            BasinStorageEvents,
-        > {
-            self.0.event_with_filter(::core::default::Default::default())
+        ) -> ::ethers::contract::builders::Event<::std::sync::Arc<M>, M, BasinStorageEvents>
+        {
+            self.0
+                .event_with_filter(::core::default::Default::default())
         }
     }
-    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>>
-    for BasinStorage<M> {
+    impl<M: ::ethers::providers::Middleware> From<::ethers::contract::Contract<M>> for BasinStorage<M> {
         fn from(contract: ::ethers::contract::Contract<M>) -> Self {
             Self::new(contract.address(), contract.client())
         }
@@ -1428,7 +1191,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "ActorError", abi = "ActorError(int256)")]
     pub struct ActorError {
@@ -1443,7 +1206,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "ActorNotFound", abi = "ActorNotFound()")]
     pub struct ActorNotFound;
@@ -1456,9 +1219,12 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
-    #[etherror(name = "DealEpochAlreadyExists", abi = "DealEpochAlreadyExists(uint256)")]
+    #[etherror(
+        name = "DealEpochAlreadyExists",
+        abi = "DealEpochAlreadyExists(uint256)"
+    )]
     pub struct DealEpochAlreadyExists {
         pub epoch: ::ethers::core::types::U256,
     }
@@ -1471,7 +1237,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "FailToCallActor", abi = "FailToCallActor()")]
     pub struct FailToCallActor;
@@ -1484,7 +1250,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "InvalidCodec", abi = "InvalidCodec(uint64)")]
     pub struct InvalidCodec(pub u64);
@@ -1497,7 +1263,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "InvalidResponseLength", abi = "InvalidResponseLength()")]
     pub struct InvalidResponseLength;
@@ -1510,7 +1276,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "NotEnoughBalance", abi = "NotEnoughBalance(uint256,uint256)")]
     pub struct NotEnoughBalance {
@@ -1526,7 +1292,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "PubAlreadyExists", abi = "PubAlreadyExists(string)")]
     pub struct PubAlreadyExists {
@@ -1541,7 +1307,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[etherror(name = "PubDoesNotExist", abi = "PubDoesNotExist(string)")]
     pub struct PubDoesNotExist {
@@ -1568,50 +1334,42 @@ pub mod basin_storage {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded)
-                = <::std::string::String as ::ethers::core::abi::AbiDecode>::decode(
-                    data,
-                ) {
+            if let Ok(decoded) =
+                <::std::string::String as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::RevertString(decoded));
             }
-            if let Ok(decoded)
-                = <ActorError as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <ActorError as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::ActorError(decoded));
             }
-            if let Ok(decoded)
-                = <ActorNotFound as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <ActorNotFound as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::ActorNotFound(decoded));
             }
-            if let Ok(decoded)
-                = <DealEpochAlreadyExists as ::ethers::core::abi::AbiDecode>::decode(
-                    data,
-                ) {
+            if let Ok(decoded) =
+                <DealEpochAlreadyExists as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::DealEpochAlreadyExists(decoded));
             }
-            if let Ok(decoded)
-                = <FailToCallActor as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <FailToCallActor as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::FailToCallActor(decoded));
             }
-            if let Ok(decoded)
-                = <InvalidCodec as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <InvalidCodec as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::InvalidCodec(decoded));
             }
-            if let Ok(decoded)
-                = <InvalidResponseLength as ::ethers::core::abi::AbiDecode>::decode(
-                    data,
-                ) {
+            if let Ok(decoded) =
+                <InvalidResponseLength as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::InvalidResponseLength(decoded));
             }
-            if let Ok(decoded)
-                = <NotEnoughBalance as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <NotEnoughBalance as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::NotEnoughBalance(decoded));
             }
-            if let Ok(decoded)
-                = <PubAlreadyExists as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <PubAlreadyExists as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::PubAlreadyExists(decoded));
             }
-            if let Ok(decoded)
-                = <PubDoesNotExist as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <PubDoesNotExist as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::PubDoesNotExist(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -1620,33 +1378,19 @@ pub mod basin_storage {
     impl ::ethers::core::abi::AbiEncode for BasinStorageErrors {
         fn encode(self) -> ::std::vec::Vec<u8> {
             match self {
-                Self::ActorError(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::ActorNotFound(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::ActorError(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::ActorNotFound(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::DealEpochAlreadyExists(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
-                Self::FailToCallActor(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::InvalidCodec(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::FailToCallActor(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::InvalidCodec(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::InvalidResponseLength(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
-                Self::NotEnoughBalance(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::PubAlreadyExists(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::PubDoesNotExist(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::NotEnoughBalance(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::PubAlreadyExists(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::PubDoesNotExist(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::RevertString(s) => ::ethers::core::abi::AbiEncode::encode(s),
             }
         }
@@ -1655,36 +1399,31 @@ pub mod basin_storage {
         fn valid_selector(selector: [u8; 4]) -> bool {
             match selector {
                 [0x08, 0xc3, 0x79, 0xa0] => true,
-                _ if selector
-                    == <ActorError as ::ethers::contract::EthError>::selector() => true,
-                _ if selector
-                    == <ActorNotFound as ::ethers::contract::EthError>::selector() => {
+                _ if selector == <ActorError as ::ethers::contract::EthError>::selector() => true,
+                _ if selector == <ActorNotFound as ::ethers::contract::EthError>::selector() => {
                     true
                 }
                 _ if selector
-                    == <DealEpochAlreadyExists as ::ethers::contract::EthError>::selector() => {
+                    == <DealEpochAlreadyExists as ::ethers::contract::EthError>::selector() =>
+                {
                     true
                 }
-                _ if selector
-                    == <FailToCallActor as ::ethers::contract::EthError>::selector() => {
+                _ if selector == <FailToCallActor as ::ethers::contract::EthError>::selector() => {
                     true
                 }
+                _ if selector == <InvalidCodec as ::ethers::contract::EthError>::selector() => true,
                 _ if selector
-                    == <InvalidCodec as ::ethers::contract::EthError>::selector() => true,
-                _ if selector
-                    == <InvalidResponseLength as ::ethers::contract::EthError>::selector() => {
+                    == <InvalidResponseLength as ::ethers::contract::EthError>::selector() =>
+                {
                     true
                 }
-                _ if selector
-                    == <NotEnoughBalance as ::ethers::contract::EthError>::selector() => {
+                _ if selector == <NotEnoughBalance as ::ethers::contract::EthError>::selector() => {
                     true
                 }
-                _ if selector
-                    == <PubAlreadyExists as ::ethers::contract::EthError>::selector() => {
+                _ if selector == <PubAlreadyExists as ::ethers::contract::EthError>::selector() => {
                     true
                 }
-                _ if selector
-                    == <PubDoesNotExist as ::ethers::contract::EthError>::selector() => {
+                _ if selector == <PubDoesNotExist as ::ethers::contract::EthError>::selector() => {
                     true
                 }
                 _ => false,
@@ -1696,14 +1435,10 @@ pub mod basin_storage {
             match self {
                 Self::ActorError(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ActorNotFound(element) => ::core::fmt::Display::fmt(element, f),
-                Self::DealEpochAlreadyExists(element) => {
-                    ::core::fmt::Display::fmt(element, f)
-                }
+                Self::DealEpochAlreadyExists(element) => ::core::fmt::Display::fmt(element, f),
                 Self::FailToCallActor(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InvalidCodec(element) => ::core::fmt::Display::fmt(element, f),
-                Self::InvalidResponseLength(element) => {
-                    ::core::fmt::Display::fmt(element, f)
-                }
+                Self::InvalidResponseLength(element) => ::core::fmt::Display::fmt(element, f),
                 Self::NotEnoughBalance(element) => ::core::fmt::Display::fmt(element, f),
                 Self::PubAlreadyExists(element) => ::core::fmt::Display::fmt(element, f),
                 Self::PubDoesNotExist(element) => ::core::fmt::Display::fmt(element, f),
@@ -1769,7 +1504,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethevent(name = "DealAdded", abi = "DealAdded(uint256,string,address,string)")]
     pub struct DealAddedFilter {
@@ -1789,7 +1524,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethevent(name = "PubCreated", abi = "PubCreated(string,address)")]
     pub struct PubCreatedFilter {
@@ -1806,7 +1541,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethevent(
         name = "RoleAdminChanged",
@@ -1828,7 +1563,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethevent(name = "RoleGranted", abi = "RoleGranted(bytes32,address,address)")]
     pub struct RoleGrantedFilter {
@@ -1847,7 +1582,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethevent(name = "RoleRevoked", abi = "RoleRevoked(bytes32,address,address)")]
     pub struct RoleRevokedFilter {
@@ -1894,9 +1629,7 @@ pub mod basin_storage {
             match self {
                 Self::DealAddedFilter(element) => ::core::fmt::Display::fmt(element, f),
                 Self::PubCreatedFilter(element) => ::core::fmt::Display::fmt(element, f),
-                Self::RoleAdminChangedFilter(element) => {
-                    ::core::fmt::Display::fmt(element, f)
-                }
+                Self::RoleAdminChangedFilter(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RoleGrantedFilter(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RoleRevokedFilter(element) => ::core::fmt::Display::fmt(element, f),
             }
@@ -1936,7 +1669,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "DEFAULT_ADMIN_ROLE", abi = "DEFAULT_ADMIN_ROLE()")]
     pub struct DefaultAdminRoleCall;
@@ -1949,7 +1682,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "PUB_ADMIN_ROLE", abi = "PUB_ADMIN_ROLE()")]
     pub struct PubAdminRoleCall;
@@ -1962,7 +1695,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "addDeals", abi = "addDeals(string,(uint64,string,string)[])")]
     pub struct AddDealsCall {
@@ -1978,7 +1711,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "createPub", abi = "createPub(address,string)")]
     pub struct CreatePubCall {
@@ -1994,7 +1727,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "dealActivation", abi = "dealActivation(uint64)")]
     pub struct DealActivationCall {
@@ -2009,7 +1742,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "dealClient", abi = "dealClient(uint64)")]
     pub struct DealClientCall {
@@ -2024,7 +1757,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "dealClientCollateral", abi = "dealClientCollateral(uint64)")]
     pub struct DealClientCollateralCall {
@@ -2039,7 +1772,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "dealLabel", abi = "dealLabel(uint64)")]
     pub struct DealLabelCall {
@@ -2054,7 +1787,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "dealProvider", abi = "dealProvider(uint64)")]
     pub struct DealProviderCall {
@@ -2069,9 +1802,12 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
-    #[ethcall(name = "dealProviderCollateral", abi = "dealProviderCollateral(uint64)")]
+    #[ethcall(
+        name = "dealProviderCollateral",
+        abi = "dealProviderCollateral(uint64)"
+    )]
     pub struct DealProviderCollateralCall {
         pub deal_id: u64,
     }
@@ -2084,7 +1820,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "dealTerm", abi = "dealTerm(uint64)")]
     pub struct DealTermCall {
@@ -2099,7 +1835,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "dealTotalPrice", abi = "dealTotalPrice(uint64)")]
     pub struct DealTotalPriceCall {
@@ -2114,7 +1850,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "dealVerified", abi = "dealVerified(uint64)")]
     pub struct DealVerifiedCall {
@@ -2129,7 +1865,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "getRoleAdmin", abi = "getRoleAdmin(bytes32)")]
     pub struct GetRoleAdminCall {
@@ -2144,7 +1880,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "grantRole", abi = "grantRole(bytes32,address)")]
     pub struct GrantRoleCall {
@@ -2160,7 +1896,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "hasRole", abi = "hasRole(bytes32,address)")]
     pub struct HasRoleCall {
@@ -2176,7 +1912,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "latestNDeals", abi = "latestNDeals(string,uint256)")]
     pub struct LatestNDealsCall {
@@ -2192,9 +1928,12 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
-    #[ethcall(name = "paginatedDeals", abi = "paginatedDeals(string,uint256,uint256)")]
+    #[ethcall(
+        name = "paginatedDeals",
+        abi = "paginatedDeals(string,uint256,uint256)"
+    )]
     pub struct PaginatedDealsCall {
         pub pub_: ::std::string::String,
         pub offset: ::ethers::core::types::U256,
@@ -2209,7 +1948,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "pubsOfOwner", abi = "pubsOfOwner(address)")]
     pub struct PubsOfOwnerCall {
@@ -2224,7 +1963,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "renounceRole", abi = "renounceRole(bytes32,address)")]
     pub struct RenounceRoleCall {
@@ -2240,7 +1979,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "revokeRole", abi = "revokeRole(bytes32,address)")]
     pub struct RevokeRoleCall {
@@ -2256,7 +1995,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     #[ethcall(name = "supportsInterface", abi = "supportsInterface(bytes4)")]
     pub struct SupportsInterfaceCall {
@@ -2293,100 +2032,90 @@ pub mod basin_storage {
             data: impl AsRef<[u8]>,
         ) -> ::core::result::Result<Self, ::ethers::core::abi::AbiError> {
             let data = data.as_ref();
-            if let Ok(decoded)
-                = <DefaultAdminRoleCall as ::ethers::core::abi::AbiDecode>::decode(
-                    data,
-                ) {
+            if let Ok(decoded) =
+                <DefaultAdminRoleCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::DefaultAdminRole(decoded));
             }
-            if let Ok(decoded)
-                = <PubAdminRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <PubAdminRoleCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::PubAdminRole(decoded));
             }
-            if let Ok(decoded)
-                = <AddDealsCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <AddDealsCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::AddDeals(decoded));
             }
-            if let Ok(decoded)
-                = <CreatePubCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <CreatePubCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::CreatePub(decoded));
             }
-            if let Ok(decoded)
-                = <DealActivationCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) =
+                <DealActivationCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::DealActivation(decoded));
             }
-            if let Ok(decoded)
-                = <DealClientCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <DealClientCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DealClient(decoded));
             }
-            if let Ok(decoded)
-                = <DealClientCollateralCall as ::ethers::core::abi::AbiDecode>::decode(
-                    data,
-                ) {
+            if let Ok(decoded) =
+                <DealClientCollateralCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::DealClientCollateral(decoded));
             }
-            if let Ok(decoded)
-                = <DealLabelCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <DealLabelCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DealLabel(decoded));
             }
-            if let Ok(decoded)
-                = <DealProviderCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <DealProviderCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::DealProvider(decoded));
             }
-            if let Ok(decoded)
-                = <DealProviderCollateralCall as ::ethers::core::abi::AbiDecode>::decode(
-                    data,
-                ) {
+            if let Ok(decoded) =
+                <DealProviderCollateralCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::DealProviderCollateral(decoded));
             }
-            if let Ok(decoded)
-                = <DealTermCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <DealTermCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DealTerm(decoded));
             }
-            if let Ok(decoded)
-                = <DealTotalPriceCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) =
+                <DealTotalPriceCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::DealTotalPrice(decoded));
             }
-            if let Ok(decoded)
-                = <DealVerifiedCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <DealVerifiedCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::DealVerified(decoded));
             }
-            if let Ok(decoded)
-                = <GetRoleAdminCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <GetRoleAdminCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::GetRoleAdmin(decoded));
             }
-            if let Ok(decoded)
-                = <GrantRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <GrantRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::GrantRole(decoded));
             }
-            if let Ok(decoded)
-                = <HasRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <HasRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::HasRole(decoded));
             }
-            if let Ok(decoded)
-                = <LatestNDealsCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <LatestNDealsCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::LatestNDeals(decoded));
             }
-            if let Ok(decoded)
-                = <PaginatedDealsCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) =
+                <PaginatedDealsCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::PaginatedDeals(decoded));
             }
-            if let Ok(decoded)
-                = <PubsOfOwnerCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <PubsOfOwnerCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::PubsOfOwner(decoded));
             }
-            if let Ok(decoded)
-                = <RenounceRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <RenounceRoleCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::RenounceRole(decoded));
             }
-            if let Ok(decoded)
-                = <RevokeRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
+            if let Ok(decoded) = <RevokeRoleCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::RevokeRole(decoded));
             }
-            if let Ok(decoded)
-                = <SupportsInterfaceCall as ::ethers::core::abi::AbiDecode>::decode(
-                    data,
-                ) {
+            if let Ok(decoded) =
+                <SupportsInterfaceCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
                 return Ok(Self::SupportsInterface(decoded));
             }
             Err(::ethers::core::abi::Error::InvalidData.into())
@@ -2395,70 +2124,32 @@ pub mod basin_storage {
     impl ::ethers::core::abi::AbiEncode for BasinStorageCalls {
         fn encode(self) -> Vec<u8> {
             match self {
-                Self::DefaultAdminRole(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::PubAdminRole(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::AddDeals(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::CreatePub(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::DealActivation(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::DealClient(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::DefaultAdminRole(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::PubAdminRole(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::AddDeals(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::CreatePub(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::DealActivation(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::DealClient(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::DealClientCollateral(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
-                Self::DealLabel(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::DealProvider(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::DealLabel(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::DealProvider(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::DealProviderCollateral(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
-                Self::DealTerm(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::DealTotalPrice(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::DealVerified(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::GetRoleAdmin(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::GrantRole(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::DealTerm(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::DealTotalPrice(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::DealVerified(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::GetRoleAdmin(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::GrantRole(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::HasRole(element) => ::ethers::core::abi::AbiEncode::encode(element),
-                Self::LatestNDeals(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::PaginatedDeals(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::PubsOfOwner(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::RenounceRole(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::RevokeRole(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
-                Self::SupportsInterface(element) => {
-                    ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                Self::LatestNDeals(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::PaginatedDeals(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::PubsOfOwner(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::RenounceRole(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::RevokeRole(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::SupportsInterface(element) => ::ethers::core::abi::AbiEncode::encode(element),
             }
         }
     }
@@ -2471,14 +2162,10 @@ pub mod basin_storage {
                 Self::CreatePub(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DealActivation(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DealClient(element) => ::core::fmt::Display::fmt(element, f),
-                Self::DealClientCollateral(element) => {
-                    ::core::fmt::Display::fmt(element, f)
-                }
+                Self::DealClientCollateral(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DealLabel(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DealProvider(element) => ::core::fmt::Display::fmt(element, f),
-                Self::DealProviderCollateral(element) => {
-                    ::core::fmt::Display::fmt(element, f)
-                }
+                Self::DealProviderCollateral(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DealTerm(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DealTotalPrice(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DealVerified(element) => ::core::fmt::Display::fmt(element, f),
@@ -2613,7 +2300,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DefaultAdminRoleReturn(pub [u8; 32]);
     ///Container type for all return fields from the `PUB_ADMIN_ROLE` function with signature `PUB_ADMIN_ROLE()` and selector `0x822ba40b`
@@ -2625,7 +2312,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct PubAdminRoleReturn(pub [u8; 32]);
     ///Container type for all return fields from the `dealActivation` function with signature `dealActivation(uint64)` and selector `0x9f29370b`
@@ -2637,7 +2324,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DealActivationReturn(pub i64, pub i64);
     ///Container type for all return fields from the `dealClient` function with signature `dealClient(uint64)` and selector `0x06a09dea`
@@ -2649,7 +2336,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DealClientReturn(pub u64);
     ///Container type for all return fields from the `dealClientCollateral` function with signature `dealClientCollateral(uint64)` and selector `0x89ec0b93`
@@ -2661,7 +2348,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DealClientCollateralReturn(pub BigInt);
     ///Container type for all return fields from the `dealLabel` function with signature `dealLabel(uint64)` and selector `0x121e620e`
@@ -2673,7 +2360,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DealLabelReturn(pub ::ethers::core::types::Bytes, pub bool);
     ///Container type for all return fields from the `dealProvider` function with signature `dealProvider(uint64)` and selector `0xd06f6802`
@@ -2685,7 +2372,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DealProviderReturn(pub u64);
     ///Container type for all return fields from the `dealProviderCollateral` function with signature `dealProviderCollateral(uint64)` and selector `0x3c7e5999`
@@ -2697,7 +2384,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DealProviderCollateralReturn(pub BigInt);
     ///Container type for all return fields from the `dealTerm` function with signature `dealTerm(uint64)` and selector `0x87a41b81`
@@ -2709,7 +2396,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DealTermReturn(pub i64, pub i64);
     ///Container type for all return fields from the `dealTotalPrice` function with signature `dealTotalPrice(uint64)` and selector `0x484d5a3a`
@@ -2721,7 +2408,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DealTotalPriceReturn(pub BigInt);
     ///Container type for all return fields from the `dealVerified` function with signature `dealVerified(uint64)` and selector `0x3ff421e9`
@@ -2733,7 +2420,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DealVerifiedReturn(pub bool);
     ///Container type for all return fields from the `getRoleAdmin` function with signature `getRoleAdmin(bytes32)` and selector `0x248a9ca3`
@@ -2745,7 +2432,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct GetRoleAdminReturn(pub [u8; 32]);
     ///Container type for all return fields from the `hasRole` function with signature `hasRole(bytes32,address)` and selector `0x91d14854`
@@ -2757,7 +2444,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct HasRoleReturn(pub bool);
     ///Container type for all return fields from the `latestNDeals` function with signature `latestNDeals(string,uint256)` and selector `0x6f0a43c7`
@@ -2769,7 +2456,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct LatestNDealsReturn(pub ::std::vec::Vec<DealInfo>);
     ///Container type for all return fields from the `paginatedDeals` function with signature `paginatedDeals(string,uint256,uint256)` and selector `0x59b64c5d`
@@ -2781,7 +2468,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct PaginatedDealsReturn(pub ::std::vec::Vec<DealInfo>);
     ///Container type for all return fields from the `pubsOfOwner` function with signature `pubsOfOwner(address)` and selector `0x26294a77`
@@ -2793,7 +2480,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct PubsOfOwnerReturn(pub ::std::vec::Vec<::std::string::String>);
     ///Container type for all return fields from the `supportsInterface` function with signature `supportsInterface(bytes4)` and selector `0x01ffc9a7`
@@ -2805,7 +2492,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct SupportsInterfaceReturn(pub bool);
     ///`DealInfo(uint64,string,string)`
@@ -2817,7 +2504,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct DealInfo {
         pub id: u64,
@@ -2833,7 +2520,7 @@ pub mod basin_storage {
         Debug,
         PartialEq,
         Eq,
-        Hash
+        Hash,
     )]
     pub struct BigInt {
         pub val: ::ethers::core::types::Bytes,

--- a/lib/protocol/schema/definitions.capnp
+++ b/lib/protocol/schema/definitions.capnp
@@ -40,5 +40,5 @@ struct DealInfo {
     cid @0 :Text;
     size @1 :UInt32;
     created @2 :Text; 
-    isPermament @3 :Bool;
+    archived @3 :Bool;
 }

--- a/lib/protocol/schema/definitions.capnp
+++ b/lib/protocol/schema/definitions.capnp
@@ -37,7 +37,8 @@ struct Schema {
 }
 
 struct DealInfo {
-    id @0 :UInt64;
-    selectorPath @1 :Text;
-    cid @2 :Text;
+    cid @0 :Text;
+    size @1 :UInt32;
+    created @2 :Text; 
+    isPermament @3 :Bool;
 }

--- a/lib/protocol/src/lib.rs
+++ b/lib/protocol/src/lib.rs
@@ -1,3 +1,3 @@
 mod schema;
 
-pub use schema::{publications, schema as tableschema, tx, deal_info};
+pub use schema::{deal_info, publications, schema as tableschema, tx};

--- a/lib/protocol/src/schema.rs
+++ b/lib/protocol/src/schema.rs
@@ -3,5 +3,5 @@
 mod definitions_capnp;
 mod provider_capnp;
 
-pub use definitions_capnp::{schema, tx, deal_info};
+pub use definitions_capnp::{deal_info, schema, tx};
 pub use provider_capnp::publications;

--- a/lib/protocol/src/schema/definitions_capnp.rs
+++ b/lib/protocol/src/schema/definitions_capnp.rs
@@ -1780,24 +1780,28 @@ pub mod deal_info {
       self.reader.total_size()
     }
     #[inline]
-    pub fn get_id(self) -> u64 {
-      self.reader.get_data_field::<u64>(0)
-    }
-    #[inline]
-    pub fn get_selector_path(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+    pub fn get_cid(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
     }
     #[inline]
-    pub fn has_selector_path(&self) -> bool {
+    pub fn has_cid(&self) -> bool {
       !self.reader.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn get_cid(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+    pub fn get_size(self) -> u32 {
+      self.reader.get_data_field::<u32>(0)
+    }
+    #[inline]
+    pub fn get_created(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
       ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
     }
     #[inline]
-    pub fn has_cid(&self) -> bool {
+    pub fn has_created(&self) -> bool {
       !self.reader.get_pointer_field(1).is_null()
+    }
+    #[inline]
+    pub fn get_is_permament(self) -> bool {
+      self.reader.get_bool_field(32)
     }
   }
 
@@ -1854,44 +1858,52 @@ pub mod deal_info {
       self.builder.as_reader().total_size()
     }
     #[inline]
-    pub fn get_id(self) -> u64 {
-      self.builder.get_data_field::<u64>(0)
-    }
-    #[inline]
-    pub fn set_id(&mut self, value: u64)  {
-      self.builder.set_data_field::<u64>(0, value);
-    }
-    #[inline]
-    pub fn get_selector_path(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+    pub fn get_cid(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_selector_path(&mut self, value: ::capnp::text::Reader<'_>)  {
+    pub fn set_cid(&mut self, value: ::capnp::text::Reader<'_>)  {
       self.builder.reborrow().get_pointer_field(0).set_text(value);
     }
     #[inline]
-    pub fn init_selector_path(self, size: u32) -> ::capnp::text::Builder<'a> {
+    pub fn init_cid(self, size: u32) -> ::capnp::text::Builder<'a> {
       self.builder.get_pointer_field(0).init_text(size)
     }
     #[inline]
-    pub fn has_selector_path(&self) -> bool {
+    pub fn has_cid(&self) -> bool {
       !self.builder.is_pointer_field_null(0)
     }
     #[inline]
-    pub fn get_cid(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+    pub fn get_size(self) -> u32 {
+      self.builder.get_data_field::<u32>(0)
+    }
+    #[inline]
+    pub fn set_size(&mut self, value: u32)  {
+      self.builder.set_data_field::<u32>(0, value);
+    }
+    #[inline]
+    pub fn get_created(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_cid(&mut self, value: ::capnp::text::Reader<'_>)  {
+    pub fn set_created(&mut self, value: ::capnp::text::Reader<'_>)  {
       self.builder.reborrow().get_pointer_field(1).set_text(value);
     }
     #[inline]
-    pub fn init_cid(self, size: u32) -> ::capnp::text::Builder<'a> {
+    pub fn init_created(self, size: u32) -> ::capnp::text::Builder<'a> {
       self.builder.get_pointer_field(1).init_text(size)
     }
     #[inline]
-    pub fn has_cid(&self) -> bool {
+    pub fn has_created(&self) -> bool {
       !self.builder.is_pointer_field_null(1)
+    }
+    #[inline]
+    pub fn get_is_permament(self) -> bool {
+      self.builder.get_bool_field(32)
+    }
+    #[inline]
+    pub fn set_is_permament(&mut self, value: bool)  {
+      self.builder.set_bool_field(32, value);
     }
   }
 
@@ -1904,7 +1916,7 @@ pub mod deal_info {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 65] = [
+    pub static ENCODED_NODE: [::capnp::Word; 80] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(134, 40, 187, 117, 196, 247, 155, 198),
       ::capnp::word(25, 0, 0, 0, 1, 0, 1, 0),
@@ -1914,7 +1926,7 @@ pub mod deal_info {
       ::capnp::word(21, 0, 0, 0, 18, 1, 0, 0),
       ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(33, 0, 0, 0, 175, 0, 0, 0),
+      ::capnp::word(33, 0, 0, 0, 231, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
@@ -1923,45 +1935,35 @@ pub mod deal_info {
       ::capnp::word(58, 68, 101, 97, 108, 73, 110, 102),
       ::capnp::word(111, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(69, 0, 0, 0, 26, 0, 0, 0),
+      ::capnp::word(97, 0, 0, 0, 34, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(64, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(76, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(104, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(73, 0, 0, 0, 106, 0, 0, 0),
+      ::capnp::word(101, 0, 0, 0, 42, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(72, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(84, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(2, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(81, 0, 0, 0, 34, 0, 0, 0),
+      ::capnp::word(105, 0, 0, 0, 66, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(76, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(88, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(105, 100, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(100, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(112, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(3, 0, 0, 0, 32, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(109, 0, 0, 0, 98, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(115, 101, 108, 101, 99, 116, 111, 114),
-      ::capnp::word(80, 97, 116, 104, 0, 0, 0, 0),
-      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(108, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(120, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(99, 105, 100, 0, 0, 0, 0, 0),
       ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -1970,12 +1972,38 @@ pub mod deal_info {
       ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(115, 105, 122, 101, 0, 0, 0, 0),
+      ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(99, 114, 101, 97, 116, 101, 100, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(105, 115, 80, 101, 114, 109, 97, 109),
+      ::capnp::word(101, 110, 116, 0, 0, 0, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
-        0 => <u64 as ::capnp::introspect::Introspect>::introspect(),
-        1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+        0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+        1 => <u32 as ::capnp::introspect::Introspect>::introspect(),
         2 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+        3 => <bool as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -1987,7 +2015,7 @@ pub mod deal_info {
       nonunion_members: NONUNION_MEMBERS,
       members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
     };
-    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3];
     pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
     pub const TYPE_ID: u64 = 0xc69b_f7c4_75bb_2886;
   }

--- a/lib/protocol/src/schema/definitions_capnp.rs
+++ b/lib/protocol/src/schema/definitions_capnp.rs
@@ -1800,7 +1800,7 @@ pub mod deal_info {
       !self.reader.get_pointer_field(1).is_null()
     }
     #[inline]
-    pub fn get_is_permament(self) -> bool {
+    pub fn get_archived(self) -> bool {
       self.reader.get_bool_field(32)
     }
   }
@@ -1898,11 +1898,11 @@ pub mod deal_info {
       !self.builder.is_pointer_field_null(1)
     }
     #[inline]
-    pub fn get_is_permament(self) -> bool {
+    pub fn get_archived(self) -> bool {
       self.builder.get_bool_field(32)
     }
     #[inline]
-    pub fn set_is_permament(&mut self, value: bool)  {
+    pub fn set_archived(&mut self, value: bool)  {
       self.builder.set_bool_field(32, value);
     }
   }
@@ -1960,7 +1960,7 @@ pub mod deal_info {
       ::capnp::word(3, 0, 0, 0, 32, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(109, 0, 0, 0, 98, 0, 0, 0),
+      ::capnp::word(109, 0, 0, 0, 74, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(108, 0, 0, 0, 3, 0, 1, 0),
       ::capnp::word(120, 0, 0, 0, 2, 0, 1, 0),
@@ -1988,8 +1988,8 @@ pub mod deal_info {
       ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(105, 115, 80, 101, 114, 109, 97, 109),
-      ::capnp::word(101, 110, 116, 0, 0, 0, 0, 0),
+      ::capnp::word(97, 114, 99, 104, 105, 118, 101, 100),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),

--- a/lib/protocol/src/schema/definitions_capnp.rs
+++ b/lib/protocol/src/schema/definitions_capnp.rs
@@ -2,2021 +2,2853 @@
 // DO NOT EDIT.
 // source: schema/definitions.capnp
 
-
 pub mod tx {
-  #[derive(Copy, Clone)]
-  pub struct Owned(());
-  impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-  impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-  impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-    fn clone(&self) -> Self { *self }
-  }
-
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-    const TYPE_ID: u64 = _private::TYPE_ID;
-  }
-  impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-    fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-      Self { reader,  }
-    }
-  }
-
-  impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-    fn from(reader: Reader<'a,>) -> Self {
-      Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-    }
-  }
-
-  impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-      core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-    }
-  }
-
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-      ::core::result::Result::Ok(reader.get_struct(default)?.into())
-    }
-  }
-
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-      self.reader
-    }
-  }
-
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-    }
-  }
-
-  impl <'a,> Reader<'a,>  {
-    pub fn reborrow(&self) -> Reader<'_,> {
-      Self { .. *self }
-    }
-
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.reader.total_size()
-    }
-    #[inline]
-    pub fn get_commit_l_s_n(self) -> u64 {
-      self.reader.get_data_field::<u64>(0)
-    }
-    #[inline]
-    pub fn get_records(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::tx::record::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-    }
-    #[inline]
-    pub fn has_records(&self) -> bool {
-      !self.reader.get_pointer_field(0).is_null()
-    }
-  }
-
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 1 };
-  }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-    const TYPE_ID: u64 = _private::TYPE_ID;
-  }
-  impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-    fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-      Self { builder,  }
-    }
-  }
-
-  impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-    fn from(builder: Builder<'a,>) -> Self {
-      Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-    }
-  }
-
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-    }
-  }
-
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-      builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-    }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-      ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-    }
-  }
-
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-  }
-
-  impl <'a,> Builder<'a,>  {
-    pub fn into_reader(self) -> Reader<'a,> {
-      self.builder.into_reader().into()
-    }
-    pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { builder: self.builder.reborrow() }
-    }
-    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      self.builder.as_reader().into()
-    }
-
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.as_reader().total_size()
-    }
-    #[inline]
-    pub fn get_commit_l_s_n(self) -> u64 {
-      self.builder.get_data_field::<u64>(0)
-    }
-    #[inline]
-    pub fn set_commit_l_s_n(&mut self, value: u64)  {
-      self.builder.set_data_field::<u64>(0, value);
-    }
-    #[inline]
-    pub fn get_records(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::tx::record::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-    }
-    #[inline]
-    pub fn set_records(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::tx::record::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
-    }
-    #[inline]
-    pub fn init_records(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::tx::record::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
-    }
-    #[inline]
-    pub fn has_records(&self) -> bool {
-      !self.builder.is_pointer_field_null(0)
-    }
-  }
-
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-      Self { _typeless: typeless,  }
-    }
-  }
-  impl Pipeline  {
-  }
-  mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 56] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-      ::capnp::word(95, 249, 117, 29, 7, 93, 19, 233),
-      ::capnp::word(25, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(219, 231, 182, 117, 39, 218, 73, 140),
-      ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(21, 0, 0, 0, 226, 0, 0, 0),
-      ::capnp::word(33, 0, 0, 0, 23, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(41, 0, 0, 0, 119, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
-      ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
-      ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
-      ::capnp::word(58, 84, 120, 0, 0, 0, 0, 0),
-      ::capnp::word(4, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(72, 250, 180, 76, 230, 36, 250, 173),
-      ::capnp::word(1, 0, 0, 0, 58, 0, 0, 0),
-      ::capnp::word(82, 101, 99, 111, 114, 100, 0, 0),
-      ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(41, 0, 0, 0, 82, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(40, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(52, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(49, 0, 0, 0, 66, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(44, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(72, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(99, 111, 109, 109, 105, 116, 76, 83),
-      ::capnp::word(78, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(114, 101, 99, 111, 114, 100, 115, 0),
-      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(72, 250, 180, 76, 230, 36, 250, 173),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-    ];
-    pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-      match index {
-        0 => <u64 as ::capnp::introspect::Introspect>::introspect(),
-        1 => <::capnp::struct_list::Owned<crate::schema::definitions_capnp::tx::record::Owned> as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
-      }
-    }
-    pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-      panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-    }
-    pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-      encoded_node: &ENCODED_NODE,
-      nonunion_members: NONUNION_MEMBERS,
-      members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-    };
-    pub static NONUNION_MEMBERS : &[u16] = &[0,1];
-    pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-    pub const TYPE_ID: u64 = 0xe913_5d07_1d75_f95f;
-  }
-
-  pub mod record {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
+    impl ::capnp::introspect::Introspect for Owned {
+        fn introspect() -> ::capnp::introspect::Type {
+            ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema {
+                generic: &_private::RAW_SCHEMA,
+                field_types: _private::get_field_types,
+                annotation_types: _private::get_annotation_types,
+            })
+            .into()
+        }
+    }
+    impl ::capnp::traits::Owned for Owned {
+        type Reader<'a> = Reader<'a>;
+        type Builder<'a> = Builder<'a>;
+    }
+    impl ::capnp::traits::OwnedStruct for Owned {
+        type Reader<'a> = Reader<'a>;
+        type Builder<'a> = Builder<'a>;
+    }
+    impl ::capnp::traits::Pipelined for Owned {
+        type Pipeline = Pipeline;
     }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
+    pub struct Reader<'a> {
+        reader: ::capnp::private::layout::StructReader<'a>,
     }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
+    impl<'a> ::core::marker::Copy for Reader<'a> {}
+    impl<'a> ::core::clone::Clone for Reader<'a> {
+        fn clone(&self) -> Self {
+            *self
+        }
     }
 
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
+    impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+        const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+        fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+            Self { reader }
+        }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
+    impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+        fn from(reader: Reader<'a>) -> Self {
+            Self::Struct(::capnp::dynamic_struct::Reader::new(
+                reader.reader,
+                ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema {
+                    generic: &_private::RAW_SCHEMA,
+                    field_types: _private::get_field_types,
+                    annotation_types: _private::get_annotation_types,
+                }),
+            ))
+        }
     }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
+    impl<'a> ::core::fmt::Debug for Reader<'a> {
+        fn fmt(
+            &self,
+            f: &mut ::core::fmt::Formatter<'_>,
+        ) -> ::core::result::Result<(), ::core::fmt::Error> {
+            core::fmt::Debug::fmt(
+                &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                f,
+            )
+        }
     }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
+    impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+        fn get_from_pointer(
+            reader: &::capnp::private::layout::PointerReader<'a>,
+            default: ::core::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Self> {
+            ::core::result::Result::Ok(reader.get_struct(default)?.into())
+        }
     }
 
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_action(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_action(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-      #[inline]
-      pub fn get_timestamp(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_timestamp(&self) -> bool {
-        !self.reader.get_pointer_field(1).is_null()
-      }
-      #[inline]
-      pub fn get_schema(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_schema(&self) -> bool {
-        !self.reader.get_pointer_field(2).is_null()
-      }
-      #[inline]
-      pub fn get_table(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_table(&self) -> bool {
-        !self.reader.get_pointer_field(3).is_null()
-      }
-      #[inline]
-      pub fn get_columns(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::tx::record::column::Owned>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_columns(&self) -> bool {
-        !self.reader.get_pointer_field(4).is_null()
-      }
-      #[inline]
-      pub fn get_primary_key(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::tx::record::primary_key::Owned>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(5), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_primary_key(&self) -> bool {
-        !self.reader.get_pointer_field(5).is_null()
-      }
+    impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+            self.reader
+        }
     }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 6 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
+    impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+            self.reader
+                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+        }
     }
 
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
+    impl<'a> Reader<'a> {
+        pub fn reborrow(&self) -> Reader<'_> {
+            Self { ..*self }
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.reader.total_size()
+        }
+        #[inline]
+        pub fn get_commit_l_s_n(self) -> u64 {
+            self.reader.get_data_field::<u64>(0)
+        }
+        #[inline]
+        pub fn get_records(
+            self,
+        ) -> ::capnp::Result<
+            ::capnp::struct_list::Reader<'a, crate::schema::definitions_capnp::tx::record::Owned>,
+        > {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(0),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn has_records(&self) -> bool {
+            !self.reader.get_pointer_field(0).is_null()
+        }
     }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
+    pub struct Builder<'a> {
+        builder: ::capnp::private::layout::StructBuilder<'a>,
+    }
+    impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+        const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+            ::capnp::private::layout::StructSize {
+                data: 1,
+                pointers: 1,
+            };
+    }
+    impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+        const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+        fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+            Self { builder }
+        }
     }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
+    impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+        fn from(builder: Builder<'a>) -> Self {
+            Self::Struct(::capnp::dynamic_struct::Builder::new(
+                builder.builder,
+                ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema {
+                    generic: &_private::RAW_SCHEMA,
+                    field_types: _private::get_field_types,
+                    annotation_types: _private::get_annotation_types,
+                }),
+            ))
+        }
     }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+            self.builder
+                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+        }
     }
 
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_action(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_action(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(0).set_text(value);
-      }
-      #[inline]
-      pub fn init_action(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(0).init_text(size)
-      }
-      #[inline]
-      pub fn has_action(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-      #[inline]
-      pub fn get_timestamp(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_timestamp(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(1).set_text(value);
-      }
-      #[inline]
-      pub fn init_timestamp(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(1).init_text(size)
-      }
-      #[inline]
-      pub fn has_timestamp(&self) -> bool {
-        !self.builder.is_pointer_field_null(1)
-      }
-      #[inline]
-      pub fn get_schema(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_schema(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(2).set_text(value);
-      }
-      #[inline]
-      pub fn init_schema(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(2).init_text(size)
-      }
-      #[inline]
-      pub fn has_schema(&self) -> bool {
-        !self.builder.is_pointer_field_null(2)
-      }
-      #[inline]
-      pub fn get_table(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_table(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(3).set_text(value);
-      }
-      #[inline]
-      pub fn init_table(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(3).init_text(size)
-      }
-      #[inline]
-      pub fn has_table(&self) -> bool {
-        !self.builder.is_pointer_field_null(3)
-      }
-      #[inline]
-      pub fn get_columns(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::tx::record::column::Owned>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_columns(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::tx::record::column::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(4), value, false)
-      }
-      #[inline]
-      pub fn init_columns(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::tx::record::column::Owned> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(4), size)
-      }
-      #[inline]
-      pub fn has_columns(&self) -> bool {
-        !self.builder.is_pointer_field_null(4)
-      }
-      #[inline]
-      pub fn get_primary_key(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::tx::record::primary_key::Owned>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(5), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_primary_key(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::tx::record::primary_key::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(5), value, false)
-      }
-      #[inline]
-      pub fn init_primary_key(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::tx::record::primary_key::Owned> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(5), size)
-      }
-      #[inline]
-      pub fn has_primary_key(&self) -> bool {
-        !self.builder.is_pointer_field_null(5)
-      }
+    impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
+            builder
+                .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                .into()
+        }
+        fn get_from_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            default: ::core::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Self> {
+            ::core::result::Result::Ok(
+                builder
+                    .get_struct(
+                        <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                        default,
+                    )?
+                    .into(),
+            )
+        }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+        fn set_pointer_builder(
+            mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+            value: Self,
+            canonicalize: bool,
+        ) -> ::capnp::Result<()> {
+            pointer.set_struct(&value.reader, canonicalize)
+        }
+    }
+
+    impl<'a> Builder<'a> {
+        pub fn into_reader(self) -> Reader<'a> {
+            self.builder.into_reader().into()
+        }
+        pub fn reborrow(&mut self) -> Builder<'_> {
+            Builder {
+                builder: self.builder.reborrow(),
+            }
+        }
+        pub fn reborrow_as_reader(&self) -> Reader<'_> {
+            self.builder.as_reader().into()
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.builder.as_reader().total_size()
+        }
+        #[inline]
+        pub fn get_commit_l_s_n(self) -> u64 {
+            self.builder.get_data_field::<u64>(0)
+        }
+        #[inline]
+        pub fn set_commit_l_s_n(&mut self, value: u64) {
+            self.builder.set_data_field::<u64>(0, value);
+        }
+        #[inline]
+        pub fn get_records(
+            self,
+        ) -> ::capnp::Result<
+            ::capnp::struct_list::Builder<'a, crate::schema::definitions_capnp::tx::record::Owned>,
+        > {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(0),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_records(
+            &mut self,
+            value: ::capnp::struct_list::Reader<
+                'a,
+                crate::schema::definitions_capnp::tx::record::Owned,
+            >,
+        ) -> ::capnp::Result<()> {
+            ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.reborrow().get_pointer_field(0),
+                value,
+                false,
+            )
+        }
+        #[inline]
+        pub fn init_records(
+            self,
+            size: u32,
+        ) -> ::capnp::struct_list::Builder<'a, crate::schema::definitions_capnp::tx::record::Owned>
+        {
+            ::capnp::traits::FromPointerBuilder::init_pointer(
+                self.builder.get_pointer_field(0),
+                size,
+            )
+        }
+        #[inline]
+        pub fn has_records(&self) -> bool {
+            !self.builder.is_pointer_field_null(0)
+        }
+    }
+
+    pub struct Pipeline {
+        _typeless: ::capnp::any_pointer::Pipeline,
+    }
     impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
+        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+            Self {
+                _typeless: typeless,
+            }
+        }
     }
-    impl Pipeline  {
-    }
+    impl Pipeline {}
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 126] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(72, 250, 180, 76, 230, 36, 250, 173),
-        ::capnp::word(28, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(95, 249, 117, 29, 7, 93, 19, 233),
-        ::capnp::word(6, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 26, 1, 0, 0),
-        ::capnp::word(37, 0, 0, 0, 39, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(61, 0, 0, 0, 87, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
-        ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
-        ::capnp::word(58, 84, 120, 46, 82, 101, 99, 111),
-        ::capnp::word(114, 100, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 1, 0, 1, 0),
-        ::capnp::word(252, 136, 89, 194, 76, 213, 240, 218),
-        ::capnp::word(9, 0, 0, 0, 58, 0, 0, 0),
-        ::capnp::word(159, 234, 192, 22, 67, 0, 34, 151),
-        ::capnp::word(5, 0, 0, 0, 90, 0, 0, 0),
-        ::capnp::word(67, 111, 108, 117, 109, 110, 0, 0),
-        ::capnp::word(80, 114, 105, 109, 97, 114, 121, 75),
-        ::capnp::word(101, 121, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(24, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(153, 0, 0, 0, 58, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(148, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(160, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(157, 0, 0, 0, 82, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(156, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(168, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(165, 0, 0, 0, 58, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(160, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(172, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(169, 0, 0, 0, 50, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(164, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(176, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(4, 0, 0, 0, 4, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 4, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(173, 0, 0, 0, 66, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(168, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(196, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(5, 0, 0, 0, 5, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 5, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(193, 0, 0, 0, 90, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(192, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(220, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(97, 99, 116, 105, 111, 110, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(116, 105, 109, 101, 115, 116, 97, 109),
-        ::capnp::word(112, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(116, 97, 98, 108, 101, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(99, 111, 108, 117, 109, 110, 115, 0),
-        ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(252, 136, 89, 194, 76, 213, 240, 218),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(112, 114, 105, 109, 97, 114, 121, 75),
-        ::capnp::word(101, 121, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(159, 234, 192, 22, 67, 0, 34, 151),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
-          0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          2 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          3 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          4 => <::capnp::struct_list::Owned<crate::schema::definitions_capnp::tx::record::column::Owned> as ::capnp::introspect::Introspect>::introspect(),
-          5 => <::capnp::struct_list::Owned<crate::schema::definitions_capnp::tx::record::primary_key::Owned> as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
-        }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3,4,5];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0xadfa_24e6_4cb4_fa48;
-    }
-
-    pub mod column {
-      #[derive(Copy, Clone)]
-      pub struct Owned(());
-      impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-      impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-      pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-      impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-      impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-        fn clone(&self) -> Self { *self }
-      }
-
-      impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-        fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-          Self { reader,  }
-        }
-      }
-
-      impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-        fn from(reader: Reader<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-        }
-      }
-
-      impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-          core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-        }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(reader.get_struct(default)?.into())
-        }
-      }
-
-      impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-          self.reader
-        }
-      }
-
-      impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-          self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-        }
-      }
-
-      impl <'a,> Reader<'a,>  {
-        pub fn reborrow(&self) -> Reader<'_,> {
-          Self { .. *self }
-        }
-
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.reader.total_size()
-        }
-        #[inline]
-        pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-          ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn has_name(&self) -> bool {
-          !self.reader.get_pointer_field(0).is_null()
-        }
-        #[inline]
-        pub fn get_type(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-          ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn has_type(&self) -> bool {
-          !self.reader.get_pointer_field(1).is_null()
-        }
-        #[inline]
-        pub fn get_value(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
-          ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn has_value(&self) -> bool {
-          !self.reader.get_pointer_field(2).is_null()
-        }
-      }
-
-      pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-      impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-        const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 3 };
-      }
-      impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-        fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-          Self { builder,  }
-        }
-      }
-
-      impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-        fn from(builder: Builder<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-          self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-          builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-        }
-        fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-        }
-      }
-
-      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-      }
-
-      impl <'a,> Builder<'a,>  {
-        pub fn into_reader(self) -> Reader<'a,> {
-          self.builder.into_reader().into()
-        }
-        pub fn reborrow(&mut self) -> Builder<'_,> {
-          Builder { builder: self.builder.reborrow() }
-        }
-        pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          self.builder.as_reader().into()
-        }
-
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.builder.as_reader().total_size()
-        }
-        #[inline]
-        pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-          ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
-          self.builder.reborrow().get_pointer_field(0).set_text(value);
-        }
-        #[inline]
-        pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
-          self.builder.get_pointer_field(0).init_text(size)
-        }
-        #[inline]
-        pub fn has_name(&self) -> bool {
-          !self.builder.is_pointer_field_null(0)
-        }
-        #[inline]
-        pub fn get_type(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-          ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn set_type(&mut self, value: ::capnp::text::Reader<'_>)  {
-          self.builder.reborrow().get_pointer_field(1).set_text(value);
-        }
-        #[inline]
-        pub fn init_type(self, size: u32) -> ::capnp::text::Builder<'a> {
-          self.builder.get_pointer_field(1).init_text(size)
-        }
-        #[inline]
-        pub fn has_type(&self) -> bool {
-          !self.builder.is_pointer_field_null(1)
-        }
-        #[inline]
-        pub fn get_value(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
-          ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn set_value(&mut self, value: ::capnp::data::Reader<'_>)  {
-          self.builder.reborrow().get_pointer_field(2).set_data(value);
-        }
-        #[inline]
-        pub fn init_value(self, size: u32) -> ::capnp::data::Builder<'a> {
-          self.builder.get_pointer_field(2).init_data(size)
-        }
-        #[inline]
-        pub fn has_value(&self) -> bool {
-          !self.builder.is_pointer_field_null(2)
-        }
-      }
-
-      pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-      impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-          Self { _typeless: typeless,  }
-        }
-      }
-      impl Pipeline  {
-      }
-      mod _private {
-        pub static ENCODED_NODE: [::capnp::Word; 65] = [
-          ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-          ::capnp::word(252, 136, 89, 194, 76, 213, 240, 218),
-          ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
-          ::capnp::word(72, 250, 180, 76, 230, 36, 250, 173),
-          ::capnp::word(3, 0, 7, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(21, 0, 0, 0, 82, 1, 0, 0),
-          ::capnp::word(41, 0, 0, 0, 7, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(37, 0, 0, 0, 175, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
-          ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
-          ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
-          ::capnp::word(58, 84, 120, 46, 82, 101, 99, 111),
-          ::capnp::word(114, 100, 46, 67, 111, 108, 117, 109),
-          ::capnp::word(110, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-          ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(69, 0, 0, 0, 42, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(64, 0, 0, 0, 3, 0, 1, 0),
-          ::capnp::word(76, 0, 0, 0, 2, 0, 1, 0),
-          ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-          ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(73, 0, 0, 0, 42, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(68, 0, 0, 0, 3, 0, 1, 0),
-          ::capnp::word(80, 0, 0, 0, 2, 0, 1, 0),
-          ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
-          ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(77, 0, 0, 0, 50, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(72, 0, 0, 0, 3, 0, 1, 0),
-          ::capnp::word(84, 0, 0, 0, 2, 0, 1, 0),
-          ::capnp::word(110, 97, 109, 101, 0, 0, 0, 0),
-          ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(116, 121, 112, 101, 0, 0, 0, 0),
-          ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(118, 97, 108, 117, 101, 0, 0, 0),
-          ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        pub static ENCODED_NODE: [::capnp::Word; 56] = [
+            ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+            ::capnp::word(95, 249, 117, 29, 7, 93, 19, 233),
+            ::capnp::word(25, 0, 0, 0, 1, 0, 1, 0),
+            ::capnp::word(219, 231, 182, 117, 39, 218, 73, 140),
+            ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(21, 0, 0, 0, 226, 0, 0, 0),
+            ::capnp::word(33, 0, 0, 0, 23, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(41, 0, 0, 0, 119, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
+            ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
+            ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
+            ::capnp::word(58, 84, 120, 0, 0, 0, 0, 0),
+            ::capnp::word(4, 0, 0, 0, 1, 0, 1, 0),
+            ::capnp::word(72, 250, 180, 76, 230, 36, 250, 173),
+            ::capnp::word(1, 0, 0, 0, 58, 0, 0, 0),
+            ::capnp::word(82, 101, 99, 111, 114, 100, 0, 0),
+            ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(41, 0, 0, 0, 82, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(40, 0, 0, 0, 3, 0, 1, 0),
+            ::capnp::word(52, 0, 0, 0, 2, 0, 1, 0),
+            ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(49, 0, 0, 0, 66, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(44, 0, 0, 0, 3, 0, 1, 0),
+            ::capnp::word(72, 0, 0, 0, 2, 0, 1, 0),
+            ::capnp::word(99, 111, 109, 109, 105, 116, 76, 83),
+            ::capnp::word(78, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(114, 101, 99, 111, 114, 100, 115, 0),
+            ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+            ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(72, 250, 180, 76, 230, 36, 250, 173),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ];
         pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-          match index {
-            0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-            1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-            2 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
-            _ => panic!("invalid field index {}", index),
-          }
+            match index {
+                0 => <u64 as ::capnp::introspect::Introspect>::introspect(),
+                1 => <::capnp::struct_list::Owned<
+                    crate::schema::definitions_capnp::tx::record::Owned,
+                > as ::capnp::introspect::Introspect>::introspect(),
+                _ => panic!("invalid field index {}", index),
+            }
         }
-        pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-          panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+        pub fn get_annotation_types(
+            child_index: Option<u16>,
+            index: u32,
+        ) -> ::capnp::introspect::Type {
+            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
         }
-        pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-          encoded_node: &ENCODED_NODE,
-          nonunion_members: NONUNION_MEMBERS,
-          members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-        };
-        pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
-        pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-        pub const TYPE_ID: u64 = 0xdaf0_d54c_c259_88fc;
-      }
+        pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+            ::capnp::introspect::RawStructSchema {
+                encoded_node: &ENCODED_NODE,
+                nonunion_members: NONUNION_MEMBERS,
+                members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+            };
+        pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
+        pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub const TYPE_ID: u64 = 0xe913_5d07_1d75_f95f;
     }
 
-    pub mod primary_key {
-      #[derive(Copy, Clone)]
-      pub struct Owned(());
-      impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-      impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-      pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-      impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-      impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-        fn clone(&self) -> Self { *self }
-      }
-
-      impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-        fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-          Self { reader,  }
+    pub mod record {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
         }
-      }
-
-      impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-        fn from(reader: Reader<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
         }
-      }
-
-      impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-          core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
         }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(reader.get_struct(default)?.into())
-        }
-      }
-
-      impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-          self.reader
-        }
-      }
-
-      impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-          self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-        }
-      }
-
-      impl <'a,> Reader<'a,>  {
-        pub fn reborrow(&self) -> Reader<'_,> {
-          Self { .. *self }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.reader.total_size()
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
         }
-        #[inline]
-        pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-          ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn has_name(&self) -> bool {
-          !self.reader.get_pointer_field(0).is_null()
-        }
-        #[inline]
-        pub fn get_type(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-          ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn has_type(&self) -> bool {
-          !self.reader.get_pointer_field(1).is_null()
-        }
-      }
-
-      pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-      impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-        const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 2 };
-      }
-      impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-        fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-          Self { builder,  }
-        }
-      }
-
-      impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-        fn from(builder: Builder<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-          self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-          builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-        }
-        fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-        }
-      }
-
-      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-      }
-
-      impl <'a,> Builder<'a,>  {
-        pub fn into_reader(self) -> Reader<'a,> {
-          self.builder.into_reader().into()
-        }
-        pub fn reborrow(&mut self) -> Builder<'_,> {
-          Builder { builder: self.builder.reborrow() }
-        }
-        pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          self.builder.as_reader().into()
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.builder.as_reader().total_size()
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
         }
-        #[inline]
-        pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-          ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
         }
-        #[inline]
-        pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
-          self.builder.reborrow().get_pointer_field(0).set_text(value);
-        }
-        #[inline]
-        pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
-          self.builder.get_pointer_field(0).init_text(size)
-        }
-        #[inline]
-        pub fn has_name(&self) -> bool {
-          !self.builder.is_pointer_field_null(0)
-        }
-        #[inline]
-        pub fn get_type(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-          ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn set_type(&mut self, value: ::capnp::text::Reader<'_>)  {
-          self.builder.reborrow().get_pointer_field(1).set_text(value);
-        }
-        #[inline]
-        pub fn init_type(self, size: u32) -> ::capnp::text::Builder<'a> {
-          self.builder.get_pointer_field(1).init_text(size)
-        }
-        #[inline]
-        pub fn has_type(&self) -> bool {
-          !self.builder.is_pointer_field_null(1)
-        }
-      }
 
-      pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-      impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-          Self { _typeless: typeless,  }
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
         }
-      }
-      impl Pipeline  {
-      }
-      mod _private {
-        pub static ENCODED_NODE: [::capnp::Word; 50] = [
-          ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-          ::capnp::word(159, 234, 192, 22, 67, 0, 34, 151),
-          ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
-          ::capnp::word(72, 250, 180, 76, 230, 36, 250, 173),
-          ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(21, 0, 0, 0, 114, 1, 0, 0),
-          ::capnp::word(41, 0, 0, 0, 7, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(37, 0, 0, 0, 119, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
-          ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
-          ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
-          ::capnp::word(58, 84, 120, 46, 82, 101, 99, 111),
-          ::capnp::word(114, 100, 46, 80, 114, 105, 109, 97),
-          ::capnp::word(114, 121, 75, 101, 121, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-          ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(41, 0, 0, 0, 42, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(36, 0, 0, 0, 3, 0, 1, 0),
-          ::capnp::word(48, 0, 0, 0, 2, 0, 1, 0),
-          ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-          ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(45, 0, 0, 0, 42, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(40, 0, 0, 0, 3, 0, 1, 0),
-          ::capnp::word(52, 0, 0, 0, 2, 0, 1, 0),
-          ::capnp::word(110, 97, 109, 101, 0, 0, 0, 0),
-          ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(116, 121, 112, 101, 0, 0, 0, 0),
-          ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ];
-        pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-          match index {
-            0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-            1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-            _ => panic!("invalid field index {}", index),
-          }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
         }
-        pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-          panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
         }
-        pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-          encoded_node: &ENCODED_NODE,
-          nonunion_members: NONUNION_MEMBERS,
-          members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-        };
-        pub static NONUNION_MEMBERS : &[u16] = &[0,1];
-        pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-        pub const TYPE_ID: u64 = 0x9722_0043_16c0_ea9f;
-      }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_action(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_action(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+            #[inline]
+            pub fn get_timestamp(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_timestamp(&self) -> bool {
+                !self.reader.get_pointer_field(1).is_null()
+            }
+            #[inline]
+            pub fn get_schema(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(2),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_schema(&self) -> bool {
+                !self.reader.get_pointer_field(2).is_null()
+            }
+            #[inline]
+            pub fn get_table(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(3),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_table(&self) -> bool {
+                !self.reader.get_pointer_field(3).is_null()
+            }
+            #[inline]
+            pub fn get_columns(
+                self,
+            ) -> ::capnp::Result<
+                ::capnp::struct_list::Reader<
+                    'a,
+                    crate::schema::definitions_capnp::tx::record::column::Owned,
+                >,
+            > {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(4),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_columns(&self) -> bool {
+                !self.reader.get_pointer_field(4).is_null()
+            }
+            #[inline]
+            pub fn get_primary_key(
+                self,
+            ) -> ::capnp::Result<
+                ::capnp::struct_list::Reader<
+                    'a,
+                    crate::schema::definitions_capnp::tx::record::primary_key::Owned,
+                >,
+            > {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(5),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_primary_key(&self) -> bool {
+                !self.reader.get_pointer_field(5).is_null()
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 0,
+                    pointers: 6,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_action(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_action(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(0).set_text(value);
+            }
+            #[inline]
+            pub fn init_action(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(0).init_text(size)
+            }
+            #[inline]
+            pub fn has_action(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+            #[inline]
+            pub fn get_timestamp(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_timestamp(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(1).set_text(value);
+            }
+            #[inline]
+            pub fn init_timestamp(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(1).init_text(size)
+            }
+            #[inline]
+            pub fn has_timestamp(&self) -> bool {
+                !self.builder.is_pointer_field_null(1)
+            }
+            #[inline]
+            pub fn get_schema(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(2),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_schema(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(2).set_text(value);
+            }
+            #[inline]
+            pub fn init_schema(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(2).init_text(size)
+            }
+            #[inline]
+            pub fn has_schema(&self) -> bool {
+                !self.builder.is_pointer_field_null(2)
+            }
+            #[inline]
+            pub fn get_table(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(3),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_table(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(3).set_text(value);
+            }
+            #[inline]
+            pub fn init_table(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(3).init_text(size)
+            }
+            #[inline]
+            pub fn has_table(&self) -> bool {
+                !self.builder.is_pointer_field_null(3)
+            }
+            #[inline]
+            pub fn get_columns(
+                self,
+            ) -> ::capnp::Result<
+                ::capnp::struct_list::Builder<
+                    'a,
+                    crate::schema::definitions_capnp::tx::record::column::Owned,
+                >,
+            > {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(4),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_columns(
+                &mut self,
+                value: ::capnp::struct_list::Reader<
+                    'a,
+                    crate::schema::definitions_capnp::tx::record::column::Owned,
+                >,
+            ) -> ::capnp::Result<()> {
+                ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.reborrow().get_pointer_field(4),
+                    value,
+                    false,
+                )
+            }
+            #[inline]
+            pub fn init_columns(
+                self,
+                size: u32,
+            ) -> ::capnp::struct_list::Builder<
+                'a,
+                crate::schema::definitions_capnp::tx::record::column::Owned,
+            > {
+                ::capnp::traits::FromPointerBuilder::init_pointer(
+                    self.builder.get_pointer_field(4),
+                    size,
+                )
+            }
+            #[inline]
+            pub fn has_columns(&self) -> bool {
+                !self.builder.is_pointer_field_null(4)
+            }
+            #[inline]
+            pub fn get_primary_key(
+                self,
+            ) -> ::capnp::Result<
+                ::capnp::struct_list::Builder<
+                    'a,
+                    crate::schema::definitions_capnp::tx::record::primary_key::Owned,
+                >,
+            > {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(5),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_primary_key(
+                &mut self,
+                value: ::capnp::struct_list::Reader<
+                    'a,
+                    crate::schema::definitions_capnp::tx::record::primary_key::Owned,
+                >,
+            ) -> ::capnp::Result<()> {
+                ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.reborrow().get_pointer_field(5),
+                    value,
+                    false,
+                )
+            }
+            #[inline]
+            pub fn init_primary_key(
+                self,
+                size: u32,
+            ) -> ::capnp::struct_list::Builder<
+                'a,
+                crate::schema::definitions_capnp::tx::record::primary_key::Owned,
+            > {
+                ::capnp::traits::FromPointerBuilder::init_pointer(
+                    self.builder.get_pointer_field(5),
+                    size,
+                )
+            }
+            #[inline]
+            pub fn has_primary_key(&self) -> bool {
+                !self.builder.is_pointer_field_null(5)
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 126] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(72, 250, 180, 76, 230, 36, 250, 173),
+                ::capnp::word(28, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(95, 249, 117, 29, 7, 93, 19, 233),
+                ::capnp::word(6, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 26, 1, 0, 0),
+                ::capnp::word(37, 0, 0, 0, 39, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(61, 0, 0, 0, 87, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
+                ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
+                ::capnp::word(58, 84, 120, 46, 82, 101, 99, 111),
+                ::capnp::word(114, 100, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(8, 0, 0, 0, 1, 0, 1, 0),
+                ::capnp::word(252, 136, 89, 194, 76, 213, 240, 218),
+                ::capnp::word(9, 0, 0, 0, 58, 0, 0, 0),
+                ::capnp::word(159, 234, 192, 22, 67, 0, 34, 151),
+                ::capnp::word(5, 0, 0, 0, 90, 0, 0, 0),
+                ::capnp::word(67, 111, 108, 117, 109, 110, 0, 0),
+                ::capnp::word(80, 114, 105, 109, 97, 114, 121, 75),
+                ::capnp::word(101, 121, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(24, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(153, 0, 0, 0, 58, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(148, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(160, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(157, 0, 0, 0, 82, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(156, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(168, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(165, 0, 0, 0, 58, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(160, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(172, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(169, 0, 0, 0, 50, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(164, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(176, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(4, 0, 0, 0, 4, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 4, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(173, 0, 0, 0, 66, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(168, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(196, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(5, 0, 0, 0, 5, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 5, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(193, 0, 0, 0, 90, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(192, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(220, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(97, 99, 116, 105, 111, 110, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(116, 105, 109, 101, 115, 116, 97, 109),
+                ::capnp::word(112, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(116, 97, 98, 108, 101, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(99, 111, 108, 117, 109, 110, 115, 0),
+                ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(252, 136, 89, 194, 76, 213, 240, 218),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(112, 114, 105, 109, 97, 114, 121, 75),
+                ::capnp::word(101, 121, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(159, 234, 192, 22, 67, 0, 34, 151),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
+                    0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    2 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    3 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    4 => <::capnp::struct_list::Owned<
+                        crate::schema::definitions_capnp::tx::record::column::Owned,
+                    > as ::capnp::introspect::Introspect>::introspect(),
+                    5 => <::capnp::struct_list::Owned<
+                        crate::schema::definitions_capnp::tx::record::primary_key::Owned,
+                    > as ::capnp::introspect::Introspect>::introspect(),
+                    _ => panic!("invalid field index {}", index),
+                }
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3, 4, 5];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0xadfa_24e6_4cb4_fa48;
+        }
+
+        pub mod column {
+            #[derive(Copy, Clone)]
+            pub struct Owned(());
+            impl ::capnp::introspect::Introspect for Owned {
+                fn introspect() -> ::capnp::introspect::Type {
+                    ::capnp::introspect::TypeVariant::Struct(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    )
+                    .into()
+                }
+            }
+            impl ::capnp::traits::Owned for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::OwnedStruct for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::Pipelined for Owned {
+                type Pipeline = Pipeline;
+            }
+
+            pub struct Reader<'a> {
+                reader: ::capnp::private::layout::StructReader<'a>,
+            }
+            impl<'a> ::core::marker::Copy for Reader<'a> {}
+            impl<'a> ::core::clone::Clone for Reader<'a> {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+
+            impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+                fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                    Self { reader }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+                fn from(reader: Reader<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Reader::new(
+                        reader.reader,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::core::fmt::Debug for Reader<'a> {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                    core::fmt::Debug::fmt(
+                        &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                        f,
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+                fn get_from_pointer(
+                    reader: &::capnp::private::layout::PointerReader<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(reader.get_struct(default)?.into())
+                }
+            }
+
+            impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+                fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                    self.reader
+                }
+            }
+
+            impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+                fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                    self.reader
+                        .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                }
+            }
+
+            impl<'a> Reader<'a> {
+                pub fn reborrow(&self) -> Reader<'_> {
+                    Self { ..*self }
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.reader.total_size()
+                }
+                #[inline]
+                pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                    ::capnp::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn has_name(&self) -> bool {
+                    !self.reader.get_pointer_field(0).is_null()
+                }
+                #[inline]
+                pub fn get_type(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                    ::capnp::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(1),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn has_type(&self) -> bool {
+                    !self.reader.get_pointer_field(1).is_null()
+                }
+                #[inline]
+                pub fn get_value(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
+                    ::capnp::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(2),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn has_value(&self) -> bool {
+                    !self.reader.get_pointer_field(2).is_null()
+                }
+            }
+
+            pub struct Builder<'a> {
+                builder: ::capnp::private::layout::StructBuilder<'a>,
+            }
+            impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+                const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                    ::capnp::private::layout::StructSize {
+                        data: 0,
+                        pointers: 3,
+                    };
+            }
+            impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+                fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                    Self { builder }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+                fn from(builder: Builder<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Builder::new(
+                        builder.builder,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+                fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                    self.builder
+                        .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+                fn init_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    _size: u32,
+                ) -> Self {
+                    builder
+                        .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                        .into()
+                }
+                fn get_from_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(
+                        builder
+                            .get_struct(
+                                <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                                default,
+                            )?
+                            .into(),
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+                fn set_pointer_builder(
+                    mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                    value: Self,
+                    canonicalize: bool,
+                ) -> ::capnp::Result<()> {
+                    pointer.set_struct(&value.reader, canonicalize)
+                }
+            }
+
+            impl<'a> Builder<'a> {
+                pub fn into_reader(self) -> Reader<'a> {
+                    self.builder.into_reader().into()
+                }
+                pub fn reborrow(&mut self) -> Builder<'_> {
+                    Builder {
+                        builder: self.builder.reborrow(),
+                    }
+                }
+                pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                    self.builder.as_reader().into()
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.builder.as_reader().total_size()
+                }
+                #[inline]
+                pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                        self.builder.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>) {
+                    self.builder.reborrow().get_pointer_field(0).set_text(value);
+                }
+                #[inline]
+                pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+                    self.builder.get_pointer_field(0).init_text(size)
+                }
+                #[inline]
+                pub fn has_name(&self) -> bool {
+                    !self.builder.is_pointer_field_null(0)
+                }
+                #[inline]
+                pub fn get_type(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                        self.builder.get_pointer_field(1),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn set_type(&mut self, value: ::capnp::text::Reader<'_>) {
+                    self.builder.reborrow().get_pointer_field(1).set_text(value);
+                }
+                #[inline]
+                pub fn init_type(self, size: u32) -> ::capnp::text::Builder<'a> {
+                    self.builder.get_pointer_field(1).init_text(size)
+                }
+                #[inline]
+                pub fn has_type(&self) -> bool {
+                    !self.builder.is_pointer_field_null(1)
+                }
+                #[inline]
+                pub fn get_value(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
+                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                        self.builder.get_pointer_field(2),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn set_value(&mut self, value: ::capnp::data::Reader<'_>) {
+                    self.builder.reborrow().get_pointer_field(2).set_data(value);
+                }
+                #[inline]
+                pub fn init_value(self, size: u32) -> ::capnp::data::Builder<'a> {
+                    self.builder.get_pointer_field(2).init_data(size)
+                }
+                #[inline]
+                pub fn has_value(&self) -> bool {
+                    !self.builder.is_pointer_field_null(2)
+                }
+            }
+
+            pub struct Pipeline {
+                _typeless: ::capnp::any_pointer::Pipeline,
+            }
+            impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+                fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                    Self {
+                        _typeless: typeless,
+                    }
+                }
+            }
+            impl Pipeline {}
+            mod _private {
+                pub static ENCODED_NODE: [::capnp::Word; 65] = [
+                    ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                    ::capnp::word(252, 136, 89, 194, 76, 213, 240, 218),
+                    ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
+                    ::capnp::word(72, 250, 180, 76, 230, 36, 250, 173),
+                    ::capnp::word(3, 0, 7, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(21, 0, 0, 0, 82, 1, 0, 0),
+                    ::capnp::word(41, 0, 0, 0, 7, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(37, 0, 0, 0, 175, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
+                    ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
+                    ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
+                    ::capnp::word(58, 84, 120, 46, 82, 101, 99, 111),
+                    ::capnp::word(114, 100, 46, 67, 111, 108, 117, 109),
+                    ::capnp::word(110, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
+                    ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(69, 0, 0, 0, 42, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(64, 0, 0, 0, 3, 0, 1, 0),
+                    ::capnp::word(76, 0, 0, 0, 2, 0, 1, 0),
+                    ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+                    ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(73, 0, 0, 0, 42, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(68, 0, 0, 0, 3, 0, 1, 0),
+                    ::capnp::word(80, 0, 0, 0, 2, 0, 1, 0),
+                    ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
+                    ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(77, 0, 0, 0, 50, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(72, 0, 0, 0, 3, 0, 1, 0),
+                    ::capnp::word(84, 0, 0, 0, 2, 0, 1, 0),
+                    ::capnp::word(110, 97, 109, 101, 0, 0, 0, 0),
+                    ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(116, 121, 112, 101, 0, 0, 0, 0),
+                    ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(118, 97, 108, 117, 101, 0, 0, 0),
+                    ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ];
+                pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                    match index {
+                        0 => {
+                            <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect()
+                        }
+                        1 => {
+                            <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect()
+                        }
+                        2 => {
+                            <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect()
+                        }
+                        _ => panic!("invalid field index {}", index),
+                    }
+                }
+                pub fn get_annotation_types(
+                    child_index: Option<u16>,
+                    index: u32,
+                ) -> ::capnp::introspect::Type {
+                    panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+                }
+                pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                    ::capnp::introspect::RawStructSchema {
+                        encoded_node: &ENCODED_NODE,
+                        nonunion_members: NONUNION_MEMBERS,
+                        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    };
+                pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
+                pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+                pub const TYPE_ID: u64 = 0xdaf0_d54c_c259_88fc;
+            }
+        }
+
+        pub mod primary_key {
+            #[derive(Copy, Clone)]
+            pub struct Owned(());
+            impl ::capnp::introspect::Introspect for Owned {
+                fn introspect() -> ::capnp::introspect::Type {
+                    ::capnp::introspect::TypeVariant::Struct(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    )
+                    .into()
+                }
+            }
+            impl ::capnp::traits::Owned for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::OwnedStruct for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::Pipelined for Owned {
+                type Pipeline = Pipeline;
+            }
+
+            pub struct Reader<'a> {
+                reader: ::capnp::private::layout::StructReader<'a>,
+            }
+            impl<'a> ::core::marker::Copy for Reader<'a> {}
+            impl<'a> ::core::clone::Clone for Reader<'a> {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+
+            impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+                fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                    Self { reader }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+                fn from(reader: Reader<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Reader::new(
+                        reader.reader,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::core::fmt::Debug for Reader<'a> {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                    core::fmt::Debug::fmt(
+                        &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                        f,
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+                fn get_from_pointer(
+                    reader: &::capnp::private::layout::PointerReader<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(reader.get_struct(default)?.into())
+                }
+            }
+
+            impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+                fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                    self.reader
+                }
+            }
+
+            impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+                fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                    self.reader
+                        .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                }
+            }
+
+            impl<'a> Reader<'a> {
+                pub fn reborrow(&self) -> Reader<'_> {
+                    Self { ..*self }
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.reader.total_size()
+                }
+                #[inline]
+                pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                    ::capnp::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn has_name(&self) -> bool {
+                    !self.reader.get_pointer_field(0).is_null()
+                }
+                #[inline]
+                pub fn get_type(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                    ::capnp::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(1),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn has_type(&self) -> bool {
+                    !self.reader.get_pointer_field(1).is_null()
+                }
+            }
+
+            pub struct Builder<'a> {
+                builder: ::capnp::private::layout::StructBuilder<'a>,
+            }
+            impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+                const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                    ::capnp::private::layout::StructSize {
+                        data: 0,
+                        pointers: 2,
+                    };
+            }
+            impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+                fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                    Self { builder }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+                fn from(builder: Builder<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Builder::new(
+                        builder.builder,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+                fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                    self.builder
+                        .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+                fn init_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    _size: u32,
+                ) -> Self {
+                    builder
+                        .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                        .into()
+                }
+                fn get_from_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(
+                        builder
+                            .get_struct(
+                                <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                                default,
+                            )?
+                            .into(),
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+                fn set_pointer_builder(
+                    mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                    value: Self,
+                    canonicalize: bool,
+                ) -> ::capnp::Result<()> {
+                    pointer.set_struct(&value.reader, canonicalize)
+                }
+            }
+
+            impl<'a> Builder<'a> {
+                pub fn into_reader(self) -> Reader<'a> {
+                    self.builder.into_reader().into()
+                }
+                pub fn reborrow(&mut self) -> Builder<'_> {
+                    Builder {
+                        builder: self.builder.reborrow(),
+                    }
+                }
+                pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                    self.builder.as_reader().into()
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.builder.as_reader().total_size()
+                }
+                #[inline]
+                pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                        self.builder.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>) {
+                    self.builder.reborrow().get_pointer_field(0).set_text(value);
+                }
+                #[inline]
+                pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+                    self.builder.get_pointer_field(0).init_text(size)
+                }
+                #[inline]
+                pub fn has_name(&self) -> bool {
+                    !self.builder.is_pointer_field_null(0)
+                }
+                #[inline]
+                pub fn get_type(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                        self.builder.get_pointer_field(1),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn set_type(&mut self, value: ::capnp::text::Reader<'_>) {
+                    self.builder.reborrow().get_pointer_field(1).set_text(value);
+                }
+                #[inline]
+                pub fn init_type(self, size: u32) -> ::capnp::text::Builder<'a> {
+                    self.builder.get_pointer_field(1).init_text(size)
+                }
+                #[inline]
+                pub fn has_type(&self) -> bool {
+                    !self.builder.is_pointer_field_null(1)
+                }
+            }
+
+            pub struct Pipeline {
+                _typeless: ::capnp::any_pointer::Pipeline,
+            }
+            impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+                fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                    Self {
+                        _typeless: typeless,
+                    }
+                }
+            }
+            impl Pipeline {}
+            mod _private {
+                pub static ENCODED_NODE: [::capnp::Word; 50] = [
+                    ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                    ::capnp::word(159, 234, 192, 22, 67, 0, 34, 151),
+                    ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
+                    ::capnp::word(72, 250, 180, 76, 230, 36, 250, 173),
+                    ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(21, 0, 0, 0, 114, 1, 0, 0),
+                    ::capnp::word(41, 0, 0, 0, 7, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(37, 0, 0, 0, 119, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
+                    ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
+                    ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
+                    ::capnp::word(58, 84, 120, 46, 82, 101, 99, 111),
+                    ::capnp::word(114, 100, 46, 80, 114, 105, 109, 97),
+                    ::capnp::word(114, 121, 75, 101, 121, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
+                    ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(41, 0, 0, 0, 42, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(36, 0, 0, 0, 3, 0, 1, 0),
+                    ::capnp::word(48, 0, 0, 0, 2, 0, 1, 0),
+                    ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+                    ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(45, 0, 0, 0, 42, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(40, 0, 0, 0, 3, 0, 1, 0),
+                    ::capnp::word(52, 0, 0, 0, 2, 0, 1, 0),
+                    ::capnp::word(110, 97, 109, 101, 0, 0, 0, 0),
+                    ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(116, 121, 112, 101, 0, 0, 0, 0),
+                    ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ];
+                pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                    match index {
+                        0 => {
+                            <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect()
+                        }
+                        1 => {
+                            <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect()
+                        }
+                        _ => panic!("invalid field index {}", index),
+                    }
+                }
+                pub fn get_annotation_types(
+                    child_index: Option<u16>,
+                    index: u32,
+                ) -> ::capnp::introspect::Type {
+                    panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+                }
+                pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                    ::capnp::introspect::RawStructSchema {
+                        encoded_node: &ENCODED_NODE,
+                        nonunion_members: NONUNION_MEMBERS,
+                        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    };
+                pub static NONUNION_MEMBERS: &[u16] = &[0, 1];
+                pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+                pub const TYPE_ID: u64 = 0x9722_0043_16c0_ea9f;
+            }
+        }
     }
-  }
 }
 
 pub mod schema {
-  #[derive(Copy, Clone)]
-  pub struct Owned(());
-  impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-  impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-  impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-    fn clone(&self) -> Self { *self }
-  }
-
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-    const TYPE_ID: u64 = _private::TYPE_ID;
-  }
-  impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-    fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-      Self { reader,  }
-    }
-  }
-
-  impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-    fn from(reader: Reader<'a,>) -> Self {
-      Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-    }
-  }
-
-  impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-      core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-    }
-  }
-
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-      ::core::result::Result::Ok(reader.get_struct(default)?.into())
-    }
-  }
-
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-      self.reader
-    }
-  }
-
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-    }
-  }
-
-  impl <'a,> Reader<'a,>  {
-    pub fn reborrow(&self) -> Reader<'_,> {
-      Self { .. *self }
-    }
-
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.reader.total_size()
-    }
-    #[inline]
-    pub fn get_columns(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::schema::column::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-    }
-    #[inline]
-    pub fn has_columns(&self) -> bool {
-      !self.reader.get_pointer_field(0).is_null()
-    }
-  }
-
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
-  }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-    const TYPE_ID: u64 = _private::TYPE_ID;
-  }
-  impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-    fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-      Self { builder,  }
-    }
-  }
-
-  impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-    fn from(builder: Builder<'a,>) -> Self {
-      Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-    }
-  }
-
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-    }
-  }
-
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-      builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-    }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-      ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-    }
-  }
-
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-  }
-
-  impl <'a,> Builder<'a,>  {
-    pub fn into_reader(self) -> Reader<'a,> {
-      self.builder.into_reader().into()
-    }
-    pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { builder: self.builder.reborrow() }
-    }
-    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      self.builder.as_reader().into()
-    }
-
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.as_reader().total_size()
-    }
-    #[inline]
-    pub fn get_columns(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::schema::column::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-    }
-    #[inline]
-    pub fn set_columns(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::schema::column::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
-    }
-    #[inline]
-    pub fn init_columns(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::schema::column::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
-    }
-    #[inline]
-    pub fn has_columns(&self) -> bool {
-      !self.builder.is_pointer_field_null(0)
-    }
-  }
-
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-      Self { _typeless: typeless,  }
-    }
-  }
-  impl Pipeline  {
-  }
-  mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 40] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-      ::capnp::word(67, 198, 188, 198, 149, 50, 198, 178),
-      ::capnp::word(25, 0, 0, 0, 1, 0, 0, 0),
-      ::capnp::word(219, 231, 182, 117, 39, 218, 73, 140),
-      ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(21, 0, 0, 0, 2, 1, 0, 0),
-      ::capnp::word(33, 0, 0, 0, 23, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(41, 0, 0, 0, 63, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
-      ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
-      ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
-      ::capnp::word(58, 83, 99, 104, 101, 109, 97, 0),
-      ::capnp::word(4, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(90, 26, 190, 80, 220, 51, 238, 198),
-      ::capnp::word(1, 0, 0, 0, 58, 0, 0, 0),
-      ::capnp::word(67, 111, 108, 117, 109, 110, 0, 0),
-      ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(13, 0, 0, 0, 66, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(36, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(99, 111, 108, 117, 109, 110, 115, 0),
-      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(90, 26, 190, 80, 220, 51, 238, 198),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-    ];
-    pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-      match index {
-        0 => <::capnp::struct_list::Owned<crate::schema::definitions_capnp::schema::column::Owned> as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
-      }
-    }
-    pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-      panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-    }
-    pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-      encoded_node: &ENCODED_NODE,
-      nonunion_members: NONUNION_MEMBERS,
-      members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-    };
-    pub static NONUNION_MEMBERS : &[u16] = &[0];
-    pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-    pub const TYPE_ID: u64 = 0xb2c6_3295_c6bc_c643;
-  }
-
-  pub mod column {
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
-    }
-
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_name(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-      #[inline]
-      pub fn get_type(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_type(&self) -> bool {
-        !self.reader.get_pointer_field(1).is_null()
-      }
-      #[inline]
-      pub fn get_is_nullable(self) -> bool {
-        self.reader.get_bool_field(0)
-      }
-      #[inline]
-      pub fn get_is_part_of_primary_key(self) -> bool {
-        self.reader.get_bool_field(1)
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 2 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(0).set_text(value);
-      }
-      #[inline]
-      pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(0).init_text(size)
-      }
-      #[inline]
-      pub fn has_name(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-      #[inline]
-      pub fn get_type(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_type(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(1).set_text(value);
-      }
-      #[inline]
-      pub fn init_type(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(1).init_text(size)
-      }
-      #[inline]
-      pub fn has_type(&self) -> bool {
-        !self.builder.is_pointer_field_null(1)
-      }
-      #[inline]
-      pub fn get_is_nullable(self) -> bool {
-        self.builder.get_bool_field(0)
-      }
-      #[inline]
-      pub fn set_is_nullable(&mut self, value: bool)  {
-        self.builder.set_bool_field(0, value);
-      }
-      #[inline]
-      pub fn get_is_part_of_primary_key(self) -> bool {
-        self.builder.get_bool_field(1)
-      }
-      #[inline]
-      pub fn set_is_part_of_primary_key(&mut self, value: bool)  {
-        self.builder.set_bool_field(1, value);
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 82] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(90, 26, 190, 80, 220, 51, 238, 198),
-        ::capnp::word(32, 0, 0, 0, 1, 0, 1, 0),
-        ::capnp::word(67, 198, 188, 198, 149, 50, 198, 178),
-        ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 58, 1, 0, 0),
-        ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(33, 0, 0, 0, 231, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
-        ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
-        ::capnp::word(58, 83, 99, 104, 101, 109, 97, 46),
-        ::capnp::word(67, 111, 108, 117, 109, 110, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-        ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(97, 0, 0, 0, 42, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(104, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(101, 0, 0, 0, 42, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(105, 0, 0, 0, 90, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(104, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(116, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(3, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(113, 0, 0, 0, 154, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(116, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(128, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(110, 97, 109, 101, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(116, 121, 112, 101, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(105, 115, 78, 117, 108, 108, 97, 98),
-        ::capnp::word(108, 101, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(105, 115, 80, 97, 114, 116, 79, 102),
-        ::capnp::word(80, 114, 105, 109, 97, 114, 121, 75),
-        ::capnp::word(101, 121, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
-          0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          2 => <bool as ::capnp::introspect::Introspect>::introspect(),
-          3 => <bool as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
+    impl ::capnp::introspect::Introspect for Owned {
+        fn introspect() -> ::capnp::introspect::Type {
+            ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema {
+                generic: &_private::RAW_SCHEMA,
+                field_types: _private::get_field_types,
+                annotation_types: _private::get_annotation_types,
+            })
+            .into()
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0xc6ee_33dc_50be_1a5a;
     }
-  }
+    impl ::capnp::traits::Owned for Owned {
+        type Reader<'a> = Reader<'a>;
+        type Builder<'a> = Builder<'a>;
+    }
+    impl ::capnp::traits::OwnedStruct for Owned {
+        type Reader<'a> = Reader<'a>;
+        type Builder<'a> = Builder<'a>;
+    }
+    impl ::capnp::traits::Pipelined for Owned {
+        type Pipeline = Pipeline;
+    }
+
+    pub struct Reader<'a> {
+        reader: ::capnp::private::layout::StructReader<'a>,
+    }
+    impl<'a> ::core::marker::Copy for Reader<'a> {}
+    impl<'a> ::core::clone::Clone for Reader<'a> {
+        fn clone(&self) -> Self {
+            *self
+        }
+    }
+
+    impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+        const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+        fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+            Self { reader }
+        }
+    }
+
+    impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+        fn from(reader: Reader<'a>) -> Self {
+            Self::Struct(::capnp::dynamic_struct::Reader::new(
+                reader.reader,
+                ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema {
+                    generic: &_private::RAW_SCHEMA,
+                    field_types: _private::get_field_types,
+                    annotation_types: _private::get_annotation_types,
+                }),
+            ))
+        }
+    }
+
+    impl<'a> ::core::fmt::Debug for Reader<'a> {
+        fn fmt(
+            &self,
+            f: &mut ::core::fmt::Formatter<'_>,
+        ) -> ::core::result::Result<(), ::core::fmt::Error> {
+            core::fmt::Debug::fmt(
+                &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                f,
+            )
+        }
+    }
+
+    impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+        fn get_from_pointer(
+            reader: &::capnp::private::layout::PointerReader<'a>,
+            default: ::core::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Self> {
+            ::core::result::Result::Ok(reader.get_struct(default)?.into())
+        }
+    }
+
+    impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+            self.reader
+        }
+    }
+
+    impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+            self.reader
+                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+        }
+    }
+
+    impl<'a> Reader<'a> {
+        pub fn reborrow(&self) -> Reader<'_> {
+            Self { ..*self }
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.reader.total_size()
+        }
+        #[inline]
+        pub fn get_columns(
+            self,
+        ) -> ::capnp::Result<
+            ::capnp::struct_list::Reader<
+                'a,
+                crate::schema::definitions_capnp::schema::column::Owned,
+            >,
+        > {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(0),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn has_columns(&self) -> bool {
+            !self.reader.get_pointer_field(0).is_null()
+        }
+    }
+
+    pub struct Builder<'a> {
+        builder: ::capnp::private::layout::StructBuilder<'a>,
+    }
+    impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+        const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+            ::capnp::private::layout::StructSize {
+                data: 0,
+                pointers: 1,
+            };
+    }
+    impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+        const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+        fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+            Self { builder }
+        }
+    }
+
+    impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+        fn from(builder: Builder<'a>) -> Self {
+            Self::Struct(::capnp::dynamic_struct::Builder::new(
+                builder.builder,
+                ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema {
+                    generic: &_private::RAW_SCHEMA,
+                    field_types: _private::get_field_types,
+                    annotation_types: _private::get_annotation_types,
+                }),
+            ))
+        }
+    }
+
+    impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+            self.builder
+                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+        }
+    }
+
+    impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
+            builder
+                .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                .into()
+        }
+        fn get_from_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            default: ::core::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Self> {
+            ::core::result::Result::Ok(
+                builder
+                    .get_struct(
+                        <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                        default,
+                    )?
+                    .into(),
+            )
+        }
+    }
+
+    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+        fn set_pointer_builder(
+            mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+            value: Self,
+            canonicalize: bool,
+        ) -> ::capnp::Result<()> {
+            pointer.set_struct(&value.reader, canonicalize)
+        }
+    }
+
+    impl<'a> Builder<'a> {
+        pub fn into_reader(self) -> Reader<'a> {
+            self.builder.into_reader().into()
+        }
+        pub fn reborrow(&mut self) -> Builder<'_> {
+            Builder {
+                builder: self.builder.reborrow(),
+            }
+        }
+        pub fn reborrow_as_reader(&self) -> Reader<'_> {
+            self.builder.as_reader().into()
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.builder.as_reader().total_size()
+        }
+        #[inline]
+        pub fn get_columns(
+            self,
+        ) -> ::capnp::Result<
+            ::capnp::struct_list::Builder<
+                'a,
+                crate::schema::definitions_capnp::schema::column::Owned,
+            >,
+        > {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(0),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_columns(
+            &mut self,
+            value: ::capnp::struct_list::Reader<
+                'a,
+                crate::schema::definitions_capnp::schema::column::Owned,
+            >,
+        ) -> ::capnp::Result<()> {
+            ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.reborrow().get_pointer_field(0),
+                value,
+                false,
+            )
+        }
+        #[inline]
+        pub fn init_columns(
+            self,
+            size: u32,
+        ) -> ::capnp::struct_list::Builder<
+            'a,
+            crate::schema::definitions_capnp::schema::column::Owned,
+        > {
+            ::capnp::traits::FromPointerBuilder::init_pointer(
+                self.builder.get_pointer_field(0),
+                size,
+            )
+        }
+        #[inline]
+        pub fn has_columns(&self) -> bool {
+            !self.builder.is_pointer_field_null(0)
+        }
+    }
+
+    pub struct Pipeline {
+        _typeless: ::capnp::any_pointer::Pipeline,
+    }
+    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+            Self {
+                _typeless: typeless,
+            }
+        }
+    }
+    impl Pipeline {}
+    mod _private {
+        pub static ENCODED_NODE: [::capnp::Word; 40] = [
+            ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+            ::capnp::word(67, 198, 188, 198, 149, 50, 198, 178),
+            ::capnp::word(25, 0, 0, 0, 1, 0, 0, 0),
+            ::capnp::word(219, 231, 182, 117, 39, 218, 73, 140),
+            ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(21, 0, 0, 0, 2, 1, 0, 0),
+            ::capnp::word(33, 0, 0, 0, 23, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(41, 0, 0, 0, 63, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
+            ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
+            ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
+            ::capnp::word(58, 83, 99, 104, 101, 109, 97, 0),
+            ::capnp::word(4, 0, 0, 0, 1, 0, 1, 0),
+            ::capnp::word(90, 26, 190, 80, 220, 51, 238, 198),
+            ::capnp::word(1, 0, 0, 0, 58, 0, 0, 0),
+            ::capnp::word(67, 111, 108, 117, 109, 110, 0, 0),
+            ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(13, 0, 0, 0, 66, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
+            ::capnp::word(36, 0, 0, 0, 2, 0, 1, 0),
+            ::capnp::word(99, 111, 108, 117, 109, 110, 115, 0),
+            ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+            ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(90, 26, 190, 80, 220, 51, 238, 198),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ];
+        pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+            match index {
+                0 => <::capnp::struct_list::Owned<
+                    crate::schema::definitions_capnp::schema::column::Owned,
+                > as ::capnp::introspect::Introspect>::introspect(),
+                _ => panic!("invalid field index {}", index),
+            }
+        }
+        pub fn get_annotation_types(
+            child_index: Option<u16>,
+            index: u32,
+        ) -> ::capnp::introspect::Type {
+            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+        }
+        pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+            ::capnp::introspect::RawStructSchema {
+                encoded_node: &ENCODED_NODE,
+                nonunion_members: NONUNION_MEMBERS,
+                members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+            };
+        pub static NONUNION_MEMBERS: &[u16] = &[0];
+        pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub const TYPE_ID: u64 = 0xb2c6_3295_c6bc_c643;
+    }
+
+    pub mod column {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_name(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+            #[inline]
+            pub fn get_type(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_type(&self) -> bool {
+                !self.reader.get_pointer_field(1).is_null()
+            }
+            #[inline]
+            pub fn get_is_nullable(self) -> bool {
+                self.reader.get_bool_field(0)
+            }
+            #[inline]
+            pub fn get_is_part_of_primary_key(self) -> bool {
+                self.reader.get_bool_field(1)
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 1,
+                    pointers: 2,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(0).set_text(value);
+            }
+            #[inline]
+            pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(0).init_text(size)
+            }
+            #[inline]
+            pub fn has_name(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+            #[inline]
+            pub fn get_type(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_type(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(1).set_text(value);
+            }
+            #[inline]
+            pub fn init_type(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(1).init_text(size)
+            }
+            #[inline]
+            pub fn has_type(&self) -> bool {
+                !self.builder.is_pointer_field_null(1)
+            }
+            #[inline]
+            pub fn get_is_nullable(self) -> bool {
+                self.builder.get_bool_field(0)
+            }
+            #[inline]
+            pub fn set_is_nullable(&mut self, value: bool) {
+                self.builder.set_bool_field(0, value);
+            }
+            #[inline]
+            pub fn get_is_part_of_primary_key(self) -> bool {
+                self.builder.get_bool_field(1)
+            }
+            #[inline]
+            pub fn set_is_part_of_primary_key(&mut self, value: bool) {
+                self.builder.set_bool_field(1, value);
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 82] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(90, 26, 190, 80, 220, 51, 238, 198),
+                ::capnp::word(32, 0, 0, 0, 1, 0, 1, 0),
+                ::capnp::word(67, 198, 188, 198, 149, 50, 198, 178),
+                ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 58, 1, 0, 0),
+                ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(33, 0, 0, 0, 231, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
+                ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
+                ::capnp::word(58, 83, 99, 104, 101, 109, 97, 46),
+                ::capnp::word(67, 111, 108, 117, 109, 110, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
+                ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(97, 0, 0, 0, 42, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(104, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(101, 0, 0, 0, 42, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(105, 0, 0, 0, 90, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(104, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(116, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(3, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(113, 0, 0, 0, 154, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(116, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(128, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(110, 97, 109, 101, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(116, 121, 112, 101, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(105, 115, 78, 117, 108, 108, 97, 98),
+                ::capnp::word(108, 101, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(105, 115, 80, 97, 114, 116, 79, 102),
+                ::capnp::word(80, 114, 105, 109, 97, 114, 121, 75),
+                ::capnp::word(101, 121, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
+                    0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    2 => <bool as ::capnp::introspect::Introspect>::introspect(),
+                    3 => <bool as ::capnp::introspect::Introspect>::introspect(),
+                    _ => panic!("invalid field index {}", index),
+                }
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0xc6ee_33dc_50be_1a5a;
+        }
+    }
 }
 
 pub mod deal_info {
-  #[derive(Copy, Clone)]
-  pub struct Owned(());
-  impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-  impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-  impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-    fn clone(&self) -> Self { *self }
-  }
-
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-    const TYPE_ID: u64 = _private::TYPE_ID;
-  }
-  impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-    fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-      Self { reader,  }
+    #[derive(Copy, Clone)]
+    pub struct Owned(());
+    impl ::capnp::introspect::Introspect for Owned {
+        fn introspect() -> ::capnp::introspect::Type {
+            ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema {
+                generic: &_private::RAW_SCHEMA,
+                field_types: _private::get_field_types,
+                annotation_types: _private::get_annotation_types,
+            })
+            .into()
+        }
     }
-  }
-
-  impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-    fn from(reader: Reader<'a,>) -> Self {
-      Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+    impl ::capnp::traits::Owned for Owned {
+        type Reader<'a> = Reader<'a>;
+        type Builder<'a> = Builder<'a>;
     }
-  }
-
-  impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-      core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
+    impl ::capnp::traits::OwnedStruct for Owned {
+        type Reader<'a> = Reader<'a>;
+        type Builder<'a> = Builder<'a>;
     }
-  }
-
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-      ::core::result::Result::Ok(reader.get_struct(default)?.into())
-    }
-  }
-
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-      self.reader
-    }
-  }
-
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-    }
-  }
-
-  impl <'a,> Reader<'a,>  {
-    pub fn reborrow(&self) -> Reader<'_,> {
-      Self { .. *self }
+    impl ::capnp::traits::Pipelined for Owned {
+        type Pipeline = Pipeline;
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.reader.total_size()
+    pub struct Reader<'a> {
+        reader: ::capnp::private::layout::StructReader<'a>,
     }
-    #[inline]
-    pub fn get_cid(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-    }
-    #[inline]
-    pub fn has_cid(&self) -> bool {
-      !self.reader.get_pointer_field(0).is_null()
-    }
-    #[inline]
-    pub fn get_size(self) -> u32 {
-      self.reader.get_data_field::<u32>(0)
-    }
-    #[inline]
-    pub fn get_created(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
-    }
-    #[inline]
-    pub fn has_created(&self) -> bool {
-      !self.reader.get_pointer_field(1).is_null()
-    }
-    #[inline]
-    pub fn get_archived(self) -> bool {
-      self.reader.get_bool_field(32)
-    }
-  }
-
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 2 };
-  }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-    const TYPE_ID: u64 = _private::TYPE_ID;
-  }
-  impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-    fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-      Self { builder,  }
-    }
-  }
-
-  impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-    fn from(builder: Builder<'a,>) -> Self {
-      Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-    }
-  }
-
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-    }
-  }
-
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-      builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-    }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-      ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-    }
-  }
-
-  impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-  }
-
-  impl <'a,> Builder<'a,>  {
-    pub fn into_reader(self) -> Reader<'a,> {
-      self.builder.into_reader().into()
-    }
-    pub fn reborrow(&mut self) -> Builder<'_,> {
-      Builder { builder: self.builder.reborrow() }
-    }
-    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-      self.builder.as_reader().into()
+    impl<'a> ::core::marker::Copy for Reader<'a> {}
+    impl<'a> ::core::clone::Clone for Reader<'a> {
+        fn clone(&self) -> Self {
+            *self
+        }
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.as_reader().total_size()
+    impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+        const TYPE_ID: u64 = _private::TYPE_ID;
     }
-    #[inline]
-    pub fn get_cid(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+        fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+            Self { reader }
+        }
     }
-    #[inline]
-    pub fn set_cid(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.reborrow().get_pointer_field(0).set_text(value);
-    }
-    #[inline]
-    pub fn init_cid(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(0).init_text(size)
-    }
-    #[inline]
-    pub fn has_cid(&self) -> bool {
-      !self.builder.is_pointer_field_null(0)
-    }
-    #[inline]
-    pub fn get_size(self) -> u32 {
-      self.builder.get_data_field::<u32>(0)
-    }
-    #[inline]
-    pub fn set_size(&mut self, value: u32)  {
-      self.builder.set_data_field::<u32>(0, value);
-    }
-    #[inline]
-    pub fn get_created(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
-    }
-    #[inline]
-    pub fn set_created(&mut self, value: ::capnp::text::Reader<'_>)  {
-      self.builder.reborrow().get_pointer_field(1).set_text(value);
-    }
-    #[inline]
-    pub fn init_created(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(1).init_text(size)
-    }
-    #[inline]
-    pub fn has_created(&self) -> bool {
-      !self.builder.is_pointer_field_null(1)
-    }
-    #[inline]
-    pub fn get_archived(self) -> bool {
-      self.builder.get_bool_field(32)
-    }
-    #[inline]
-    pub fn set_archived(&mut self, value: bool)  {
-      self.builder.set_bool_field(32, value);
-    }
-  }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-      Self { _typeless: typeless,  }
+    impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+        fn from(reader: Reader<'a>) -> Self {
+            Self::Struct(::capnp::dynamic_struct::Reader::new(
+                reader.reader,
+                ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema {
+                    generic: &_private::RAW_SCHEMA,
+                    field_types: _private::get_field_types,
+                    annotation_types: _private::get_annotation_types,
+                }),
+            ))
+        }
     }
-  }
-  impl Pipeline  {
-  }
-  mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 80] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-      ::capnp::word(134, 40, 187, 117, 196, 247, 155, 198),
-      ::capnp::word(25, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(219, 231, 182, 117, 39, 218, 73, 140),
-      ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(21, 0, 0, 0, 18, 1, 0, 0),
-      ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(33, 0, 0, 0, 231, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
-      ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
-      ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
-      ::capnp::word(58, 68, 101, 97, 108, 73, 110, 102),
-      ::capnp::word(111, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(97, 0, 0, 0, 34, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(104, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(101, 0, 0, 0, 42, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(2, 0, 0, 0, 1, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(105, 0, 0, 0, 66, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(100, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(112, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(3, 0, 0, 0, 32, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(109, 0, 0, 0, 74, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(108, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(120, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(99, 105, 100, 0, 0, 0, 0, 0),
-      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(115, 105, 122, 101, 0, 0, 0, 0),
-      ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(99, 114, 101, 97, 116, 101, 100, 0),
-      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(97, 114, 99, 104, 105, 118, 101, 100),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-    ];
-    pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-      match index {
-        0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-        1 => <u32 as ::capnp::introspect::Introspect>::introspect(),
-        2 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-        3 => <bool as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
-      }
+
+    impl<'a> ::core::fmt::Debug for Reader<'a> {
+        fn fmt(
+            &self,
+            f: &mut ::core::fmt::Formatter<'_>,
+        ) -> ::core::result::Result<(), ::core::fmt::Error> {
+            core::fmt::Debug::fmt(
+                &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                f,
+            )
+        }
     }
-    pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-      panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+
+    impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+        fn get_from_pointer(
+            reader: &::capnp::private::layout::PointerReader<'a>,
+            default: ::core::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Self> {
+            ::core::result::Result::Ok(reader.get_struct(default)?.into())
+        }
     }
-    pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-      encoded_node: &ENCODED_NODE,
-      nonunion_members: NONUNION_MEMBERS,
-      members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-    };
-    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3];
-    pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-    pub const TYPE_ID: u64 = 0xc69b_f7c4_75bb_2886;
-  }
+
+    impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+            self.reader
+        }
+    }
+
+    impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+            self.reader
+                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+        }
+    }
+
+    impl<'a> Reader<'a> {
+        pub fn reborrow(&self) -> Reader<'_> {
+            Self { ..*self }
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.reader.total_size()
+        }
+        #[inline]
+        pub fn get_cid(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(0),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn has_cid(&self) -> bool {
+            !self.reader.get_pointer_field(0).is_null()
+        }
+        #[inline]
+        pub fn get_size(self) -> u32 {
+            self.reader.get_data_field::<u32>(0)
+        }
+        #[inline]
+        pub fn get_created(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(1),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn has_created(&self) -> bool {
+            !self.reader.get_pointer_field(1).is_null()
+        }
+        #[inline]
+        pub fn get_archived(self) -> bool {
+            self.reader.get_bool_field(32)
+        }
+    }
+
+    pub struct Builder<'a> {
+        builder: ::capnp::private::layout::StructBuilder<'a>,
+    }
+    impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+        const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+            ::capnp::private::layout::StructSize {
+                data: 1,
+                pointers: 2,
+            };
+    }
+    impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+        const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+        fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+            Self { builder }
+        }
+    }
+
+    impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+        fn from(builder: Builder<'a>) -> Self {
+            Self::Struct(::capnp::dynamic_struct::Builder::new(
+                builder.builder,
+                ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema {
+                    generic: &_private::RAW_SCHEMA,
+                    field_types: _private::get_field_types,
+                    annotation_types: _private::get_annotation_types,
+                }),
+            ))
+        }
+    }
+
+    impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+            self.builder
+                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+        }
+    }
+
+    impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
+            builder
+                .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                .into()
+        }
+        fn get_from_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            default: ::core::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Self> {
+            ::core::result::Result::Ok(
+                builder
+                    .get_struct(
+                        <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                        default,
+                    )?
+                    .into(),
+            )
+        }
+    }
+
+    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+        fn set_pointer_builder(
+            mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+            value: Self,
+            canonicalize: bool,
+        ) -> ::capnp::Result<()> {
+            pointer.set_struct(&value.reader, canonicalize)
+        }
+    }
+
+    impl<'a> Builder<'a> {
+        pub fn into_reader(self) -> Reader<'a> {
+            self.builder.into_reader().into()
+        }
+        pub fn reborrow(&mut self) -> Builder<'_> {
+            Builder {
+                builder: self.builder.reborrow(),
+            }
+        }
+        pub fn reborrow_as_reader(&self) -> Reader<'_> {
+            self.builder.as_reader().into()
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.builder.as_reader().total_size()
+        }
+        #[inline]
+        pub fn get_cid(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(0),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_cid(&mut self, value: ::capnp::text::Reader<'_>) {
+            self.builder.reborrow().get_pointer_field(0).set_text(value);
+        }
+        #[inline]
+        pub fn init_cid(self, size: u32) -> ::capnp::text::Builder<'a> {
+            self.builder.get_pointer_field(0).init_text(size)
+        }
+        #[inline]
+        pub fn has_cid(&self) -> bool {
+            !self.builder.is_pointer_field_null(0)
+        }
+        #[inline]
+        pub fn get_size(self) -> u32 {
+            self.builder.get_data_field::<u32>(0)
+        }
+        #[inline]
+        pub fn set_size(&mut self, value: u32) {
+            self.builder.set_data_field::<u32>(0, value);
+        }
+        #[inline]
+        pub fn get_created(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(1),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_created(&mut self, value: ::capnp::text::Reader<'_>) {
+            self.builder.reborrow().get_pointer_field(1).set_text(value);
+        }
+        #[inline]
+        pub fn init_created(self, size: u32) -> ::capnp::text::Builder<'a> {
+            self.builder.get_pointer_field(1).init_text(size)
+        }
+        #[inline]
+        pub fn has_created(&self) -> bool {
+            !self.builder.is_pointer_field_null(1)
+        }
+        #[inline]
+        pub fn get_archived(self) -> bool {
+            self.builder.get_bool_field(32)
+        }
+        #[inline]
+        pub fn set_archived(&mut self, value: bool) {
+            self.builder.set_bool_field(32, value);
+        }
+    }
+
+    pub struct Pipeline {
+        _typeless: ::capnp::any_pointer::Pipeline,
+    }
+    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+            Self {
+                _typeless: typeless,
+            }
+        }
+    }
+    impl Pipeline {}
+    mod _private {
+        pub static ENCODED_NODE: [::capnp::Word; 80] = [
+            ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+            ::capnp::word(134, 40, 187, 117, 196, 247, 155, 198),
+            ::capnp::word(25, 0, 0, 0, 1, 0, 1, 0),
+            ::capnp::word(219, 231, 182, 117, 39, 218, 73, 140),
+            ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(21, 0, 0, 0, 18, 1, 0, 0),
+            ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(33, 0, 0, 0, 231, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(115, 99, 104, 101, 109, 97, 47, 100),
+            ::capnp::word(101, 102, 105, 110, 105, 116, 105, 111),
+            ::capnp::word(110, 115, 46, 99, 97, 112, 110, 112),
+            ::capnp::word(58, 68, 101, 97, 108, 73, 110, 102),
+            ::capnp::word(111, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
+            ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(97, 0, 0, 0, 34, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
+            ::capnp::word(104, 0, 0, 0, 2, 0, 1, 0),
+            ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(101, 0, 0, 0, 42, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
+            ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
+            ::capnp::word(2, 0, 0, 0, 1, 0, 0, 0),
+            ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(105, 0, 0, 0, 66, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(100, 0, 0, 0, 3, 0, 1, 0),
+            ::capnp::word(112, 0, 0, 0, 2, 0, 1, 0),
+            ::capnp::word(3, 0, 0, 0, 32, 0, 0, 0),
+            ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(109, 0, 0, 0, 74, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(108, 0, 0, 0, 3, 0, 1, 0),
+            ::capnp::word(120, 0, 0, 0, 2, 0, 1, 0),
+            ::capnp::word(99, 105, 100, 0, 0, 0, 0, 0),
+            ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(115, 105, 122, 101, 0, 0, 0, 0),
+            ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(99, 114, 101, 97, 116, 101, 100, 0),
+            ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(97, 114, 99, 104, 105, 118, 101, 100),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ];
+        pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+            match index {
+                0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                1 => <u32 as ::capnp::introspect::Introspect>::introspect(),
+                2 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                3 => <bool as ::capnp::introspect::Introspect>::introspect(),
+                _ => panic!("invalid field index {}", index),
+            }
+        }
+        pub fn get_annotation_types(
+            child_index: Option<u16>,
+            index: u32,
+        ) -> ::capnp::introspect::Type {
+            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+        }
+        pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+            ::capnp::introspect::RawStructSchema {
+                encoded_node: &ENCODED_NODE,
+                nonunion_members: NONUNION_MEMBERS,
+                members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+            };
+        pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3];
+        pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+        pub const TYPE_ID: u64 = 0xc69b_f7c4_75bb_2886;
+    }
 }

--- a/lib/protocol/src/schema/provider_capnp.rs
+++ b/lib/protocol/src/schema/provider_capnp.rs
@@ -2,3901 +2,5836 @@
 // DO NOT EDIT.
 // source: schema/provider.capnp
 
-
-
 pub mod publications {
-  #![allow(unused_variables)]
-  pub type CreateParams<> = ::capnp::capability::Params<crate::schema::provider_capnp::publications::create_params::Owned>;
-  pub type CreateResults<> = ::capnp::capability::Results<crate::schema::provider_capnp::publications::create_results::Owned>;
-  pub type PushParams<> = ::capnp::capability::Params<crate::schema::provider_capnp::publications::push_params::Owned>;
-  pub type PushResults<> = ::capnp::capability::Results<crate::schema::provider_capnp::publications::push_results::Owned>;
-  pub type UploadParams<> = ::capnp::capability::Params<crate::schema::provider_capnp::publications::upload_params::Owned>;
-  pub type UploadResults<> = ::capnp::capability::Results<crate::schema::provider_capnp::publications::upload_results::Owned>;
-  pub type ListParams<> = ::capnp::capability::Params<crate::schema::provider_capnp::publications::list_params::Owned>;
-  pub type ListResults<> = ::capnp::capability::Results<crate::schema::provider_capnp::publications::list_results::Owned>;
-  pub type DealsParams<> = ::capnp::capability::Params<crate::schema::provider_capnp::publications::deals_params::Owned>;
-  pub type DealsResults<> = ::capnp::capability::Results<crate::schema::provider_capnp::publications::deals_results::Owned>;
-  pub type LatestDealsParams<> = ::capnp::capability::Params<crate::schema::provider_capnp::publications::latest_deals_params::Owned>;
-  pub type LatestDealsResults<> = ::capnp::capability::Results<crate::schema::provider_capnp::publications::latest_deals_results::Owned>;
-
-  pub struct Client {
-    pub client: ::capnp::capability::Client,
-  }
-  impl  ::capnp::capability::FromClientHook for Client {
-    fn new(hook: Box<dyn (::capnp::private::capability::ClientHook)>) -> Self {
-      Self { client: ::capnp::capability::Client::new(hook),  }
-    }
-    fn into_client_hook(self) -> Box<dyn (::capnp::private::capability::ClientHook)> {
-      self.client.hook
-    }
-    fn as_client_hook(&self) -> &dyn (::capnp::private::capability::ClientHook) {
-      &*self.client.hook
-    }
-  }
-  #[derive(Copy, Clone)]
-  pub struct Owned(());
-  impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Capability.into() } }
-  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Client; type Builder<'a> = Client; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Client; }
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Client<>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, _default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-      ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(reader.get_capability()?))
-    }
-  }
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Client<>  {
-    fn init_pointer(_builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-      unimplemented!()
-    }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-      ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(builder.get_capability()?))
-    }
-  }
-
-  impl <> ::capnp::traits::SetPointerBuilder for Client<>  {
-    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, from: Self, _canonicalize: bool) -> ::capnp::Result<()> {
-      pointer.set_capability(from.client.hook);
-      ::core::result::Result::Ok(())
-    }
-  }
-  impl  ::capnp::traits::HasTypeId for Client {
-    const TYPE_ID: u64 = _private::TYPE_ID;
-  }
-  impl  Clone for Client {
-    fn clone(&self) -> Self {
-      Self { client: ::capnp::capability::Client::new(self.client.hook.add_ref()),  }
-    }
-  }
-  impl  Client {
-    pub fn create_request(&self) -> ::capnp::capability::Request<crate::schema::provider_capnp::publications::create_params::Owned,crate::schema::provider_capnp::publications::create_results::Owned> {
-      self.client.new_call(_private::TYPE_ID, 0, ::core::option::Option::None)
-    }
-    pub fn push_request(&self) -> ::capnp::capability::Request<crate::schema::provider_capnp::publications::push_params::Owned,crate::schema::provider_capnp::publications::push_results::Owned> {
-      self.client.new_call(_private::TYPE_ID, 1, ::core::option::Option::None)
-    }
-    pub fn upload_request(&self) -> ::capnp::capability::Request<crate::schema::provider_capnp::publications::upload_params::Owned,crate::schema::provider_capnp::publications::upload_results::Owned> {
-      self.client.new_call(_private::TYPE_ID, 2, ::core::option::Option::None)
-    }
-    pub fn list_request(&self) -> ::capnp::capability::Request<crate::schema::provider_capnp::publications::list_params::Owned,crate::schema::provider_capnp::publications::list_results::Owned> {
-      self.client.new_call(_private::TYPE_ID, 3, ::core::option::Option::None)
-    }
-    pub fn deals_request(&self) -> ::capnp::capability::Request<crate::schema::provider_capnp::publications::deals_params::Owned,crate::schema::provider_capnp::publications::deals_results::Owned> {
-      self.client.new_call(_private::TYPE_ID, 4, ::core::option::Option::None)
-    }
-    pub fn latest_deals_request(&self) -> ::capnp::capability::Request<crate::schema::provider_capnp::publications::latest_deals_params::Owned,crate::schema::provider_capnp::publications::latest_deals_results::Owned> {
-      self.client.new_call(_private::TYPE_ID, 5, ::core::option::Option::None)
-    }
-  }
-  pub trait Server<>   {
-    fn create(&mut self, _: CreateParams<>, _: CreateResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method publications::Server::create not implemented".to_string())) }
-    fn push(&mut self, _: PushParams<>, _: PushResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method publications::Server::push not implemented".to_string())) }
-    fn upload(&mut self, _: UploadParams<>, _: UploadResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method publications::Server::upload not implemented".to_string())) }
-    fn list(&mut self, _: ListParams<>, _: ListResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method publications::Server::list not implemented".to_string())) }
-    fn deals(&mut self, _: DealsParams<>, _: DealsResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method publications::Server::deals not implemented".to_string())) }
-    fn latest_deals(&mut self, _: LatestDealsParams<>, _: LatestDealsResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method publications::Server::latest_deals not implemented".to_string())) }
-  }
-  pub struct ServerDispatch<_T,> {
-    pub server: _T,
-  }
-  impl <_S: Server + 'static, > ::capnp::capability::FromServer<_S> for Client   {
-    type Dispatch = ServerDispatch<_S, >;
-    fn from_server(s: _S) -> ServerDispatch<_S, > {
-      ServerDispatch { server: s,  }
-    }
-  }
-  impl <_T: Server> ::core::ops::Deref for ServerDispatch<_T> {
-    type Target = _T;
-    fn deref(&self) -> &_T { &self.server}
-  }
-  impl <_T: Server> ::core::ops::DerefMut for ServerDispatch<_T> {
-    fn deref_mut(&mut self) -> &mut _T { &mut self.server}
-  }
-  impl <_T: Server> ::capnp::capability::Server for ServerDispatch<_T> {
-    fn dispatch_call(&mut self, interface_id: u64, method_id: u16, params: ::capnp::capability::Params<::capnp::any_pointer::Owned>, results: ::capnp::capability::Results<::capnp::any_pointer::Owned>) -> ::capnp::capability::Promise<(), ::capnp::Error> {
-      match interface_id {
-        _private::TYPE_ID => Self::dispatch_call_internal(&mut self.server, method_id, params, results),
-        _ => { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("Method not implemented.".to_string())) }
-      }
-    }
-  }
-  impl <_T :Server> ServerDispatch<_T> {
-    pub fn dispatch_call_internal(server: &mut _T, method_id: u16, params: ::capnp::capability::Params<::capnp::any_pointer::Owned>, results: ::capnp::capability::Results<::capnp::any_pointer::Owned>) -> ::capnp::capability::Promise<(), ::capnp::Error> {
-      match method_id {
-        0 => server.create(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)),
-        1 => server.push(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)),
-        2 => server.upload(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)),
-        3 => server.list(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)),
-        4 => server.deals(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)),
-        5 => server.latest_deals(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)),
-        _ => { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("Method not implemented.".to_string())) }
-      }
-    }
-  }
-  pub mod _private {
-    pub const TYPE_ID: u64 = 0xfddc_20d9_68f4_17dd;
-  }
-
-
-  pub mod callback {
     #![allow(unused_variables)]
-    pub type WriteParams<> = ::capnp::capability::Params<crate::schema::provider_capnp::publications::callback::write_params::Owned>;
-    pub type WriteResults<> = ::capnp::capability::Results<crate::schema::provider_capnp::publications::callback::write_results::Owned>;
-    pub type DoneParams<> = ::capnp::capability::Params<crate::schema::provider_capnp::publications::callback::done_params::Owned>;
-    pub type DoneResults<> = ::capnp::capability::Results<crate::schema::provider_capnp::publications::callback::done_results::Owned>;
+    pub type CreateParams = ::capnp::capability::Params<
+        crate::schema::provider_capnp::publications::create_params::Owned,
+    >;
+    pub type CreateResults = ::capnp::capability::Results<
+        crate::schema::provider_capnp::publications::create_results::Owned,
+    >;
+    pub type PushParams = ::capnp::capability::Params<
+        crate::schema::provider_capnp::publications::push_params::Owned,
+    >;
+    pub type PushResults = ::capnp::capability::Results<
+        crate::schema::provider_capnp::publications::push_results::Owned,
+    >;
+    pub type UploadParams = ::capnp::capability::Params<
+        crate::schema::provider_capnp::publications::upload_params::Owned,
+    >;
+    pub type UploadResults = ::capnp::capability::Results<
+        crate::schema::provider_capnp::publications::upload_results::Owned,
+    >;
+    pub type ListParams = ::capnp::capability::Params<
+        crate::schema::provider_capnp::publications::list_params::Owned,
+    >;
+    pub type ListResults = ::capnp::capability::Results<
+        crate::schema::provider_capnp::publications::list_results::Owned,
+    >;
+    pub type DealsParams = ::capnp::capability::Params<
+        crate::schema::provider_capnp::publications::deals_params::Owned,
+    >;
+    pub type DealsResults = ::capnp::capability::Results<
+        crate::schema::provider_capnp::publications::deals_results::Owned,
+    >;
+    pub type LatestDealsParams = ::capnp::capability::Params<
+        crate::schema::provider_capnp::publications::latest_deals_params::Owned,
+    >;
+    pub type LatestDealsResults = ::capnp::capability::Results<
+        crate::schema::provider_capnp::publications::latest_deals_results::Owned,
+    >;
 
     pub struct Client {
-      pub client: ::capnp::capability::Client,
+        pub client: ::capnp::capability::Client,
     }
-    impl  ::capnp::capability::FromClientHook for Client {
-      fn new(hook: Box<dyn (::capnp::private::capability::ClientHook)>) -> Self {
-        Self { client: ::capnp::capability::Client::new(hook),  }
-      }
-      fn into_client_hook(self) -> Box<dyn (::capnp::private::capability::ClientHook)> {
-        self.client.hook
-      }
-      fn as_client_hook(&self) -> &dyn (::capnp::private::capability::ClientHook) {
-        &*self.client.hook
-      }
+    impl ::capnp::capability::FromClientHook for Client {
+        fn new(hook: Box<dyn (::capnp::private::capability::ClientHook)>) -> Self {
+            Self {
+                client: ::capnp::capability::Client::new(hook),
+            }
+        }
+        fn into_client_hook(self) -> Box<dyn (::capnp::private::capability::ClientHook)> {
+            self.client.hook
+        }
+        fn as_client_hook(&self) -> &dyn (::capnp::private::capability::ClientHook) {
+            &*self.client.hook
+        }
     }
     #[derive(Copy, Clone)]
     pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Capability.into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Client; type Builder<'a> = Client; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Client; }
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Client<>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, _default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(reader.get_capability()?))
-      }
+    impl ::capnp::introspect::Introspect for Owned {
+        fn introspect() -> ::capnp::introspect::Type {
+            ::capnp::introspect::TypeVariant::Capability.into()
+        }
     }
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Client<>  {
-      fn init_pointer(_builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        unimplemented!()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(builder.get_capability()?))
-      }
+    impl ::capnp::traits::Owned for Owned {
+        type Reader<'a> = Client;
+        type Builder<'a> = Client;
+    }
+    impl ::capnp::traits::Pipelined for Owned {
+        type Pipeline = Client;
+    }
+    impl<'a> ::capnp::traits::FromPointerReader<'a> for Client {
+        fn get_from_pointer(
+            reader: &::capnp::private::layout::PointerReader<'a>,
+            _default: ::core::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Self> {
+            ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(
+                reader.get_capability()?,
+            ))
+        }
+    }
+    impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Client {
+        fn init_pointer(
+            _builder: ::capnp::private::layout::PointerBuilder<'a>,
+            _size: u32,
+        ) -> Self {
+            unimplemented!()
+        }
+        fn get_from_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            _default: ::core::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Self> {
+            ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(
+                builder.get_capability()?,
+            ))
+        }
     }
 
-    impl <> ::capnp::traits::SetPointerBuilder for Client<>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, from: Self, _canonicalize: bool) -> ::capnp::Result<()> {
-        pointer.set_capability(from.client.hook);
-        ::core::result::Result::Ok(())
-      }
-    }
-    impl  ::capnp::traits::HasTypeId for Client {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl  Clone for Client {
-      fn clone(&self) -> Self {
-        Self { client: ::capnp::capability::Client::new(self.client.hook.add_ref()),  }
-      }
-    }
-    impl  Client {
-      pub fn write_request(&self) -> ::capnp::capability::Request<crate::schema::provider_capnp::publications::callback::write_params::Owned,crate::schema::provider_capnp::publications::callback::write_results::Owned> {
-        self.client.new_call(_private::TYPE_ID, 0, ::core::option::Option::None)
-      }
-      pub fn done_request(&self) -> ::capnp::capability::Request<crate::schema::provider_capnp::publications::callback::done_params::Owned,crate::schema::provider_capnp::publications::callback::done_results::Owned> {
-        self.client.new_call(_private::TYPE_ID, 1, ::core::option::Option::None)
-      }
-    }
-    pub trait Server<>   {
-      fn write(&mut self, _: WriteParams<>, _: WriteResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method callback::Server::write not implemented".to_string())) }
-      fn done(&mut self, _: DoneParams<>, _: DoneResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method callback::Server::done not implemented".to_string())) }
-    }
-    pub struct ServerDispatch<_T,> {
-      pub server: _T,
-    }
-    impl <_S: Server + 'static, > ::capnp::capability::FromServer<_S> for Client   {
-      type Dispatch = ServerDispatch<_S, >;
-      fn from_server(s: _S) -> ServerDispatch<_S, > {
-        ServerDispatch { server: s,  }
-      }
-    }
-    impl <_T: Server> ::core::ops::Deref for ServerDispatch<_T> {
-      type Target = _T;
-      fn deref(&self) -> &_T { &self.server}
-    }
-    impl <_T: Server> ::core::ops::DerefMut for ServerDispatch<_T> {
-      fn deref_mut(&mut self) -> &mut _T { &mut self.server}
-    }
-    impl <_T: Server> ::capnp::capability::Server for ServerDispatch<_T> {
-      fn dispatch_call(&mut self, interface_id: u64, method_id: u16, params: ::capnp::capability::Params<::capnp::any_pointer::Owned>, results: ::capnp::capability::Results<::capnp::any_pointer::Owned>) -> ::capnp::capability::Promise<(), ::capnp::Error> {
-        match interface_id {
-          _private::TYPE_ID => Self::dispatch_call_internal(&mut self.server, method_id, params, results),
-          _ => { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("Method not implemented.".to_string())) }
+    impl ::capnp::traits::SetPointerBuilder for Client {
+        fn set_pointer_builder(
+            mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+            from: Self,
+            _canonicalize: bool,
+        ) -> ::capnp::Result<()> {
+            pointer.set_capability(from.client.hook);
+            ::core::result::Result::Ok(())
         }
-      }
     }
-    impl <_T :Server> ServerDispatch<_T> {
-      pub fn dispatch_call_internal(server: &mut _T, method_id: u16, params: ::capnp::capability::Params<::capnp::any_pointer::Owned>, results: ::capnp::capability::Results<::capnp::any_pointer::Owned>) -> ::capnp::capability::Promise<(), ::capnp::Error> {
-        match method_id {
-          0 => server.write(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)),
-          1 => server.done(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)),
-          _ => { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("Method not implemented.".to_string())) }
+    impl ::capnp::traits::HasTypeId for Client {
+        const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl Clone for Client {
+        fn clone(&self) -> Self {
+            Self {
+                client: ::capnp::capability::Client::new(self.client.hook.add_ref()),
+            }
         }
-      }
+    }
+    impl Client {
+        pub fn create_request(
+            &self,
+        ) -> ::capnp::capability::Request<
+            crate::schema::provider_capnp::publications::create_params::Owned,
+            crate::schema::provider_capnp::publications::create_results::Owned,
+        > {
+            self.client
+                .new_call(_private::TYPE_ID, 0, ::core::option::Option::None)
+        }
+        pub fn push_request(
+            &self,
+        ) -> ::capnp::capability::Request<
+            crate::schema::provider_capnp::publications::push_params::Owned,
+            crate::schema::provider_capnp::publications::push_results::Owned,
+        > {
+            self.client
+                .new_call(_private::TYPE_ID, 1, ::core::option::Option::None)
+        }
+        pub fn upload_request(
+            &self,
+        ) -> ::capnp::capability::Request<
+            crate::schema::provider_capnp::publications::upload_params::Owned,
+            crate::schema::provider_capnp::publications::upload_results::Owned,
+        > {
+            self.client
+                .new_call(_private::TYPE_ID, 2, ::core::option::Option::None)
+        }
+        pub fn list_request(
+            &self,
+        ) -> ::capnp::capability::Request<
+            crate::schema::provider_capnp::publications::list_params::Owned,
+            crate::schema::provider_capnp::publications::list_results::Owned,
+        > {
+            self.client
+                .new_call(_private::TYPE_ID, 3, ::core::option::Option::None)
+        }
+        pub fn deals_request(
+            &self,
+        ) -> ::capnp::capability::Request<
+            crate::schema::provider_capnp::publications::deals_params::Owned,
+            crate::schema::provider_capnp::publications::deals_results::Owned,
+        > {
+            self.client
+                .new_call(_private::TYPE_ID, 4, ::core::option::Option::None)
+        }
+        pub fn latest_deals_request(
+            &self,
+        ) -> ::capnp::capability::Request<
+            crate::schema::provider_capnp::publications::latest_deals_params::Owned,
+            crate::schema::provider_capnp::publications::latest_deals_results::Owned,
+        > {
+            self.client
+                .new_call(_private::TYPE_ID, 5, ::core::option::Option::None)
+        }
+    }
+    pub trait Server {
+        fn create(
+            &mut self,
+            _: CreateParams,
+            _: CreateResults,
+        ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+            ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                "method publications::Server::create not implemented".to_string(),
+            ))
+        }
+        fn push(
+            &mut self,
+            _: PushParams,
+            _: PushResults,
+        ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+            ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                "method publications::Server::push not implemented".to_string(),
+            ))
+        }
+        fn upload(
+            &mut self,
+            _: UploadParams,
+            _: UploadResults,
+        ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+            ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                "method publications::Server::upload not implemented".to_string(),
+            ))
+        }
+        fn list(
+            &mut self,
+            _: ListParams,
+            _: ListResults,
+        ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+            ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                "method publications::Server::list not implemented".to_string(),
+            ))
+        }
+        fn deals(
+            &mut self,
+            _: DealsParams,
+            _: DealsResults,
+        ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+            ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                "method publications::Server::deals not implemented".to_string(),
+            ))
+        }
+        fn latest_deals(
+            &mut self,
+            _: LatestDealsParams,
+            _: LatestDealsResults,
+        ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+            ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                "method publications::Server::latest_deals not implemented".to_string(),
+            ))
+        }
+    }
+    pub struct ServerDispatch<_T> {
+        pub server: _T,
+    }
+    impl<_S: Server + 'static> ::capnp::capability::FromServer<_S> for Client {
+        type Dispatch = ServerDispatch<_S>;
+        fn from_server(s: _S) -> ServerDispatch<_S> {
+            ServerDispatch { server: s }
+        }
+    }
+    impl<_T: Server> ::core::ops::Deref for ServerDispatch<_T> {
+        type Target = _T;
+        fn deref(&self) -> &_T {
+            &self.server
+        }
+    }
+    impl<_T: Server> ::core::ops::DerefMut for ServerDispatch<_T> {
+        fn deref_mut(&mut self) -> &mut _T {
+            &mut self.server
+        }
+    }
+    impl<_T: Server> ::capnp::capability::Server for ServerDispatch<_T> {
+        fn dispatch_call(
+            &mut self,
+            interface_id: u64,
+            method_id: u16,
+            params: ::capnp::capability::Params<::capnp::any_pointer::Owned>,
+            results: ::capnp::capability::Results<::capnp::any_pointer::Owned>,
+        ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+            match interface_id {
+                _private::TYPE_ID => {
+                    Self::dispatch_call_internal(&mut self.server, method_id, params, results)
+                }
+                _ => ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                    "Method not implemented.".to_string(),
+                )),
+            }
+        }
+    }
+    impl<_T: Server> ServerDispatch<_T> {
+        pub fn dispatch_call_internal(
+            server: &mut _T,
+            method_id: u16,
+            params: ::capnp::capability::Params<::capnp::any_pointer::Owned>,
+            results: ::capnp::capability::Results<::capnp::any_pointer::Owned>,
+        ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+            match method_id {
+                0 => server.create(
+                    ::capnp::private::capability::internal_get_typed_params(params),
+                    ::capnp::private::capability::internal_get_typed_results(results),
+                ),
+                1 => server.push(
+                    ::capnp::private::capability::internal_get_typed_params(params),
+                    ::capnp::private::capability::internal_get_typed_results(results),
+                ),
+                2 => server.upload(
+                    ::capnp::private::capability::internal_get_typed_params(params),
+                    ::capnp::private::capability::internal_get_typed_results(results),
+                ),
+                3 => server.list(
+                    ::capnp::private::capability::internal_get_typed_params(params),
+                    ::capnp::private::capability::internal_get_typed_results(results),
+                ),
+                4 => server.deals(
+                    ::capnp::private::capability::internal_get_typed_params(params),
+                    ::capnp::private::capability::internal_get_typed_results(results),
+                ),
+                5 => server.latest_deals(
+                    ::capnp::private::capability::internal_get_typed_params(params),
+                    ::capnp::private::capability::internal_get_typed_results(results),
+                ),
+                _ => ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                    "Method not implemented.".to_string(),
+                )),
+            }
+        }
     }
     pub mod _private {
-      pub const TYPE_ID: u64 = 0xb492_8ae2_3403_b190;
+        pub const TYPE_ID: u64 = 0xfddc_20d9_68f4_17dd;
     }
 
-    pub mod write_params {
-      #[derive(Copy, Clone)]
-      pub struct Owned(());
-      impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-      impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    pub mod callback {
+        #![allow(unused_variables)]
+        pub type WriteParams = ::capnp::capability::Params<
+            crate::schema::provider_capnp::publications::callback::write_params::Owned,
+        >;
+        pub type WriteResults = ::capnp::capability::Results<
+            crate::schema::provider_capnp::publications::callback::write_results::Owned,
+        >;
+        pub type DoneParams = ::capnp::capability::Params<
+            crate::schema::provider_capnp::publications::callback::done_params::Owned,
+        >;
+        pub type DoneResults = ::capnp::capability::Results<
+            crate::schema::provider_capnp::publications::callback::done_results::Owned,
+        >;
 
-      pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-      impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-      impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-        fn clone(&self) -> Self { *self }
-      }
-
-      impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-        fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-          Self { reader,  }
+        pub struct Client {
+            pub client: ::capnp::capability::Client,
         }
-      }
-
-      impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-        fn from(reader: Reader<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+        impl ::capnp::capability::FromClientHook for Client {
+            fn new(hook: Box<dyn (::capnp::private::capability::ClientHook)>) -> Self {
+                Self {
+                    client: ::capnp::capability::Client::new(hook),
+                }
+            }
+            fn into_client_hook(self) -> Box<dyn (::capnp::private::capability::ClientHook)> {
+                self.client.hook
+            }
+            fn as_client_hook(&self) -> &dyn (::capnp::private::capability::ClientHook) {
+                &*self.client.hook
+            }
         }
-      }
-
-      impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-          core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Capability.into()
+            }
         }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(reader.get_struct(default)?.into())
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Client;
+            type Builder<'a> = Client;
         }
-      }
-
-      impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-          self.reader
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Client;
         }
-      }
-
-      impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-          self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Client {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                _default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(
+                    reader.get_capability()?,
+                ))
+            }
         }
-      }
-
-      impl <'a,> Reader<'a,>  {
-        pub fn reborrow(&self) -> Reader<'_,> {
-          Self { .. *self }
-        }
-
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.reader.total_size()
-        }
-        #[inline]
-        pub fn get_chunk(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
-          ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn has_chunk(&self) -> bool {
-          !self.reader.get_pointer_field(0).is_null()
-        }
-      }
-
-      pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-      impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-        const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
-      }
-      impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-        fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-          Self { builder,  }
-        }
-      }
-
-      impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-        fn from(builder: Builder<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-          self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-          builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-        }
-        fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-        }
-      }
-
-      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-      }
-
-      impl <'a,> Builder<'a,>  {
-        pub fn into_reader(self) -> Reader<'a,> {
-          self.builder.into_reader().into()
-        }
-        pub fn reborrow(&mut self) -> Builder<'_,> {
-          Builder { builder: self.builder.reborrow() }
-        }
-        pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          self.builder.as_reader().into()
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Client {
+            fn init_pointer(
+                _builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                unimplemented!()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(
+                    builder.get_capability()?,
+                ))
+            }
         }
 
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.builder.as_reader().total_size()
+        impl ::capnp::traits::SetPointerBuilder for Client {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                from: Self,
+                _canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_capability(from.client.hook);
+                ::core::result::Result::Ok(())
+            }
         }
-        #[inline]
-        pub fn get_chunk(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
-          ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+        impl ::capnp::traits::HasTypeId for Client {
+            const TYPE_ID: u64 = _private::TYPE_ID;
         }
-        #[inline]
-        pub fn set_chunk(&mut self, value: ::capnp::data::Reader<'_>)  {
-          self.builder.reborrow().get_pointer_field(0).set_data(value);
+        impl Clone for Client {
+            fn clone(&self) -> Self {
+                Self {
+                    client: ::capnp::capability::Client::new(self.client.hook.add_ref()),
+                }
+            }
         }
-        #[inline]
-        pub fn init_chunk(self, size: u32) -> ::capnp::data::Builder<'a> {
-          self.builder.get_pointer_field(0).init_data(size)
+        impl Client {
+            pub fn write_request(
+                &self,
+            ) -> ::capnp::capability::Request<
+                crate::schema::provider_capnp::publications::callback::write_params::Owned,
+                crate::schema::provider_capnp::publications::callback::write_results::Owned,
+            > {
+                self.client
+                    .new_call(_private::TYPE_ID, 0, ::core::option::Option::None)
+            }
+            pub fn done_request(
+                &self,
+            ) -> ::capnp::capability::Request<
+                crate::schema::provider_capnp::publications::callback::done_params::Owned,
+                crate::schema::provider_capnp::publications::callback::done_results::Owned,
+            > {
+                self.client
+                    .new_call(_private::TYPE_ID, 1, ::core::option::Option::None)
+            }
         }
-        #[inline]
-        pub fn has_chunk(&self) -> bool {
-          !self.builder.is_pointer_field_null(0)
+        pub trait Server {
+            fn write(
+                &mut self,
+                _: WriteParams,
+                _: WriteResults,
+            ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+                ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                    "method callback::Server::write not implemented".to_string(),
+                ))
+            }
+            fn done(
+                &mut self,
+                _: DoneParams,
+                _: DoneResults,
+            ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+                ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                    "method callback::Server::done not implemented".to_string(),
+                ))
+            }
         }
-      }
+        pub struct ServerDispatch<_T> {
+            pub server: _T,
+        }
+        impl<_S: Server + 'static> ::capnp::capability::FromServer<_S> for Client {
+            type Dispatch = ServerDispatch<_S>;
+            fn from_server(s: _S) -> ServerDispatch<_S> {
+                ServerDispatch { server: s }
+            }
+        }
+        impl<_T: Server> ::core::ops::Deref for ServerDispatch<_T> {
+            type Target = _T;
+            fn deref(&self) -> &_T {
+                &self.server
+            }
+        }
+        impl<_T: Server> ::core::ops::DerefMut for ServerDispatch<_T> {
+            fn deref_mut(&mut self) -> &mut _T {
+                &mut self.server
+            }
+        }
+        impl<_T: Server> ::capnp::capability::Server for ServerDispatch<_T> {
+            fn dispatch_call(
+                &mut self,
+                interface_id: u64,
+                method_id: u16,
+                params: ::capnp::capability::Params<::capnp::any_pointer::Owned>,
+                results: ::capnp::capability::Results<::capnp::any_pointer::Owned>,
+            ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+                match interface_id {
+                    _private::TYPE_ID => {
+                        Self::dispatch_call_internal(&mut self.server, method_id, params, results)
+                    }
+                    _ => ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                        "Method not implemented.".to_string(),
+                    )),
+                }
+            }
+        }
+        impl<_T: Server> ServerDispatch<_T> {
+            pub fn dispatch_call_internal(
+                server: &mut _T,
+                method_id: u16,
+                params: ::capnp::capability::Params<::capnp::any_pointer::Owned>,
+                results: ::capnp::capability::Results<::capnp::any_pointer::Owned>,
+            ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
+                match method_id {
+                    0 => server.write(
+                        ::capnp::private::capability::internal_get_typed_params(params),
+                        ::capnp::private::capability::internal_get_typed_results(results),
+                    ),
+                    1 => server.done(
+                        ::capnp::private::capability::internal_get_typed_params(params),
+                        ::capnp::private::capability::internal_get_typed_results(results),
+                    ),
+                    _ => ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                        "Method not implemented.".to_string(),
+                    )),
+                }
+            }
+        }
+        pub mod _private {
+            pub const TYPE_ID: u64 = 0xb492_8ae2_3403_b190;
+        }
 
-      pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-      impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-          Self { _typeless: typeless,  }
+        pub mod write_params {
+            #[derive(Copy, Clone)]
+            pub struct Owned(());
+            impl ::capnp::introspect::Introspect for Owned {
+                fn introspect() -> ::capnp::introspect::Type {
+                    ::capnp::introspect::TypeVariant::Struct(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    )
+                    .into()
+                }
+            }
+            impl ::capnp::traits::Owned for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::OwnedStruct for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::Pipelined for Owned {
+                type Pipeline = Pipeline;
+            }
+
+            pub struct Reader<'a> {
+                reader: ::capnp::private::layout::StructReader<'a>,
+            }
+            impl<'a> ::core::marker::Copy for Reader<'a> {}
+            impl<'a> ::core::clone::Clone for Reader<'a> {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+
+            impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+                fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                    Self { reader }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+                fn from(reader: Reader<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Reader::new(
+                        reader.reader,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::core::fmt::Debug for Reader<'a> {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                    core::fmt::Debug::fmt(
+                        &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                        f,
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+                fn get_from_pointer(
+                    reader: &::capnp::private::layout::PointerReader<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(reader.get_struct(default)?.into())
+                }
+            }
+
+            impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+                fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                    self.reader
+                }
+            }
+
+            impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+                fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                    self.reader
+                        .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                }
+            }
+
+            impl<'a> Reader<'a> {
+                pub fn reborrow(&self) -> Reader<'_> {
+                    Self { ..*self }
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.reader.total_size()
+                }
+                #[inline]
+                pub fn get_chunk(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
+                    ::capnp::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn has_chunk(&self) -> bool {
+                    !self.reader.get_pointer_field(0).is_null()
+                }
+            }
+
+            pub struct Builder<'a> {
+                builder: ::capnp::private::layout::StructBuilder<'a>,
+            }
+            impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+                const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                    ::capnp::private::layout::StructSize {
+                        data: 0,
+                        pointers: 1,
+                    };
+            }
+            impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+                fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                    Self { builder }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+                fn from(builder: Builder<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Builder::new(
+                        builder.builder,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+                fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                    self.builder
+                        .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+                fn init_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    _size: u32,
+                ) -> Self {
+                    builder
+                        .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                        .into()
+                }
+                fn get_from_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(
+                        builder
+                            .get_struct(
+                                <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                                default,
+                            )?
+                            .into(),
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+                fn set_pointer_builder(
+                    mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                    value: Self,
+                    canonicalize: bool,
+                ) -> ::capnp::Result<()> {
+                    pointer.set_struct(&value.reader, canonicalize)
+                }
+            }
+
+            impl<'a> Builder<'a> {
+                pub fn into_reader(self) -> Reader<'a> {
+                    self.builder.into_reader().into()
+                }
+                pub fn reborrow(&mut self) -> Builder<'_> {
+                    Builder {
+                        builder: self.builder.reborrow(),
+                    }
+                }
+                pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                    self.builder.as_reader().into()
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.builder.as_reader().total_size()
+                }
+                #[inline]
+                pub fn get_chunk(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
+                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                        self.builder.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn set_chunk(&mut self, value: ::capnp::data::Reader<'_>) {
+                    self.builder.reborrow().get_pointer_field(0).set_data(value);
+                }
+                #[inline]
+                pub fn init_chunk(self, size: u32) -> ::capnp::data::Builder<'a> {
+                    self.builder.get_pointer_field(0).init_data(size)
+                }
+                #[inline]
+                pub fn has_chunk(&self) -> bool {
+                    !self.builder.is_pointer_field_null(0)
+                }
+            }
+
+            pub struct Pipeline {
+                _typeless: ::capnp::any_pointer::Pipeline,
+            }
+            impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+                fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                    Self {
+                        _typeless: typeless,
+                    }
+                }
+            }
+            impl Pipeline {}
+            mod _private {
+                pub static ENCODED_NODE: [::capnp::Word; 36] = [
+                    ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                    ::capnp::word(61, 9, 118, 34, 9, 37, 102, 140),
+                    ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(21, 0, 0, 0, 202, 1, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(41, 0, 0, 0, 63, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                    ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                    ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                    ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                    ::capnp::word(110, 115, 46, 67, 97, 108, 108, 98),
+                    ::capnp::word(97, 99, 107, 46, 119, 114, 105, 116),
+                    ::capnp::word(101, 36, 80, 97, 114, 97, 109, 115),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(13, 0, 0, 0, 50, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
+                    ::capnp::word(20, 0, 0, 0, 2, 0, 1, 0),
+                    ::capnp::word(99, 104, 117, 110, 107, 0, 0, 0),
+                    ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ];
+                pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                    match index {
+                        0 => {
+                            <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect()
+                        }
+                        _ => panic!("invalid field index {}", index),
+                    }
+                }
+                pub fn get_annotation_types(
+                    child_index: Option<u16>,
+                    index: u32,
+                ) -> ::capnp::introspect::Type {
+                    panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+                }
+                pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                    ::capnp::introspect::RawStructSchema {
+                        encoded_node: &ENCODED_NODE,
+                        nonunion_members: NONUNION_MEMBERS,
+                        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    };
+                pub static NONUNION_MEMBERS: &[u16] = &[0];
+                pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+                pub const TYPE_ID: u64 = 0x8c66_2509_2276_093d;
+            }
         }
-      }
-      impl Pipeline  {
-      }
-      mod _private {
-        pub static ENCODED_NODE: [::capnp::Word; 36] = [
-          ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-          ::capnp::word(61, 9, 118, 34, 9, 37, 102, 140),
-          ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(21, 0, 0, 0, 202, 1, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(41, 0, 0, 0, 63, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-          ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-          ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-          ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-          ::capnp::word(110, 115, 46, 67, 97, 108, 108, 98),
-          ::capnp::word(97, 99, 107, 46, 119, 114, 105, 116),
-          ::capnp::word(101, 36, 80, 97, 114, 97, 109, 115),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(13, 0, 0, 0, 50, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
-          ::capnp::word(20, 0, 0, 0, 2, 0, 1, 0),
-          ::capnp::word(99, 104, 117, 110, 107, 0, 0, 0),
-          ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ];
-        pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-          match index {
-            0 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
-            _ => panic!("invalid field index {}", index),
-          }
+
+        pub mod write_results {
+            #[derive(Copy, Clone)]
+            pub struct Owned(());
+            impl ::capnp::introspect::Introspect for Owned {
+                fn introspect() -> ::capnp::introspect::Type {
+                    ::capnp::introspect::TypeVariant::Struct(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    )
+                    .into()
+                }
+            }
+            impl ::capnp::traits::Owned for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::OwnedStruct for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::Pipelined for Owned {
+                type Pipeline = Pipeline;
+            }
+
+            pub struct Reader<'a> {
+                reader: ::capnp::private::layout::StructReader<'a>,
+            }
+            impl<'a> ::core::marker::Copy for Reader<'a> {}
+            impl<'a> ::core::clone::Clone for Reader<'a> {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+
+            impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+                fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                    Self { reader }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+                fn from(reader: Reader<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Reader::new(
+                        reader.reader,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::core::fmt::Debug for Reader<'a> {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                    core::fmt::Debug::fmt(
+                        &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                        f,
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+                fn get_from_pointer(
+                    reader: &::capnp::private::layout::PointerReader<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(reader.get_struct(default)?.into())
+                }
+            }
+
+            impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+                fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                    self.reader
+                }
+            }
+
+            impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+                fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                    self.reader
+                        .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                }
+            }
+
+            impl<'a> Reader<'a> {
+                pub fn reborrow(&self) -> Reader<'_> {
+                    Self { ..*self }
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.reader.total_size()
+                }
+            }
+
+            pub struct Builder<'a> {
+                builder: ::capnp::private::layout::StructBuilder<'a>,
+            }
+            impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+                const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                    ::capnp::private::layout::StructSize {
+                        data: 0,
+                        pointers: 0,
+                    };
+            }
+            impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+                fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                    Self { builder }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+                fn from(builder: Builder<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Builder::new(
+                        builder.builder,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+                fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                    self.builder
+                        .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+                fn init_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    _size: u32,
+                ) -> Self {
+                    builder
+                        .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                        .into()
+                }
+                fn get_from_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(
+                        builder
+                            .get_struct(
+                                <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                                default,
+                            )?
+                            .into(),
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+                fn set_pointer_builder(
+                    mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                    value: Self,
+                    canonicalize: bool,
+                ) -> ::capnp::Result<()> {
+                    pointer.set_struct(&value.reader, canonicalize)
+                }
+            }
+
+            impl<'a> Builder<'a> {
+                pub fn into_reader(self) -> Reader<'a> {
+                    self.builder.into_reader().into()
+                }
+                pub fn reborrow(&mut self) -> Builder<'_> {
+                    Builder {
+                        builder: self.builder.reborrow(),
+                    }
+                }
+                pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                    self.builder.as_reader().into()
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.builder.as_reader().total_size()
+                }
+            }
+
+            pub struct Pipeline {
+                _typeless: ::capnp::any_pointer::Pipeline,
+            }
+            impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+                fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                    Self {
+                        _typeless: typeless,
+                    }
+                }
+            }
+            impl Pipeline {}
+            mod _private {
+                pub static ENCODED_NODE: [::capnp::Word; 20] = [
+                    ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                    ::capnp::word(229, 147, 206, 112, 112, 169, 183, 199),
+                    ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(21, 0, 0, 0, 210, 1, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                    ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                    ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                    ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                    ::capnp::word(110, 115, 46, 67, 97, 108, 108, 98),
+                    ::capnp::word(97, 99, 107, 46, 119, 114, 105, 116),
+                    ::capnp::word(101, 36, 82, 101, 115, 117, 108, 116),
+                    ::capnp::word(115, 0, 0, 0, 0, 0, 0, 0),
+                ];
+                pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                    panic!("invalid field index {}", index)
+                }
+                pub fn get_annotation_types(
+                    child_index: Option<u16>,
+                    index: u32,
+                ) -> ::capnp::introspect::Type {
+                    panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+                }
+                pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                    ::capnp::introspect::RawStructSchema {
+                        encoded_node: &ENCODED_NODE,
+                        nonunion_members: NONUNION_MEMBERS,
+                        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    };
+                pub static NONUNION_MEMBERS: &[u16] = &[];
+                pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+                pub const TYPE_ID: u64 = 0xc7b7_a970_70ce_93e5;
+            }
         }
-        pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-          panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+
+        pub mod done_params {
+            #[derive(Copy, Clone)]
+            pub struct Owned(());
+            impl ::capnp::introspect::Introspect for Owned {
+                fn introspect() -> ::capnp::introspect::Type {
+                    ::capnp::introspect::TypeVariant::Struct(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    )
+                    .into()
+                }
+            }
+            impl ::capnp::traits::Owned for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::OwnedStruct for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::Pipelined for Owned {
+                type Pipeline = Pipeline;
+            }
+
+            pub struct Reader<'a> {
+                reader: ::capnp::private::layout::StructReader<'a>,
+            }
+            impl<'a> ::core::marker::Copy for Reader<'a> {}
+            impl<'a> ::core::clone::Clone for Reader<'a> {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+
+            impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+                fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                    Self { reader }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+                fn from(reader: Reader<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Reader::new(
+                        reader.reader,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::core::fmt::Debug for Reader<'a> {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                    core::fmt::Debug::fmt(
+                        &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                        f,
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+                fn get_from_pointer(
+                    reader: &::capnp::private::layout::PointerReader<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(reader.get_struct(default)?.into())
+                }
+            }
+
+            impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+                fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                    self.reader
+                }
+            }
+
+            impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+                fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                    self.reader
+                        .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                }
+            }
+
+            impl<'a> Reader<'a> {
+                pub fn reborrow(&self) -> Reader<'_> {
+                    Self { ..*self }
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.reader.total_size()
+                }
+                #[inline]
+                pub fn get_sig(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
+                    ::capnp::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn has_sig(&self) -> bool {
+                    !self.reader.get_pointer_field(0).is_null()
+                }
+            }
+
+            pub struct Builder<'a> {
+                builder: ::capnp::private::layout::StructBuilder<'a>,
+            }
+            impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+                const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                    ::capnp::private::layout::StructSize {
+                        data: 0,
+                        pointers: 1,
+                    };
+            }
+            impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+                fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                    Self { builder }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+                fn from(builder: Builder<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Builder::new(
+                        builder.builder,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+                fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                    self.builder
+                        .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+                fn init_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    _size: u32,
+                ) -> Self {
+                    builder
+                        .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                        .into()
+                }
+                fn get_from_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(
+                        builder
+                            .get_struct(
+                                <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                                default,
+                            )?
+                            .into(),
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+                fn set_pointer_builder(
+                    mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                    value: Self,
+                    canonicalize: bool,
+                ) -> ::capnp::Result<()> {
+                    pointer.set_struct(&value.reader, canonicalize)
+                }
+            }
+
+            impl<'a> Builder<'a> {
+                pub fn into_reader(self) -> Reader<'a> {
+                    self.builder.into_reader().into()
+                }
+                pub fn reborrow(&mut self) -> Builder<'_> {
+                    Builder {
+                        builder: self.builder.reborrow(),
+                    }
+                }
+                pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                    self.builder.as_reader().into()
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.builder.as_reader().total_size()
+                }
+                #[inline]
+                pub fn get_sig(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
+                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                        self.builder.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )
+                }
+                #[inline]
+                pub fn set_sig(&mut self, value: ::capnp::data::Reader<'_>) {
+                    self.builder.reborrow().get_pointer_field(0).set_data(value);
+                }
+                #[inline]
+                pub fn init_sig(self, size: u32) -> ::capnp::data::Builder<'a> {
+                    self.builder.get_pointer_field(0).init_data(size)
+                }
+                #[inline]
+                pub fn has_sig(&self) -> bool {
+                    !self.builder.is_pointer_field_null(0)
+                }
+            }
+
+            pub struct Pipeline {
+                _typeless: ::capnp::any_pointer::Pipeline,
+            }
+            impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+                fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                    Self {
+                        _typeless: typeless,
+                    }
+                }
+            }
+            impl Pipeline {}
+            mod _private {
+                pub static ENCODED_NODE: [::capnp::Word; 35] = [
+                    ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                    ::capnp::word(245, 156, 128, 131, 9, 158, 190, 144),
+                    ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(21, 0, 0, 0, 194, 1, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(37, 0, 0, 0, 63, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                    ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                    ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                    ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                    ::capnp::word(110, 115, 46, 67, 97, 108, 108, 98),
+                    ::capnp::word(97, 99, 107, 46, 100, 111, 110, 101),
+                    ::capnp::word(36, 80, 97, 114, 97, 109, 115, 0),
+                    ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(13, 0, 0, 0, 34, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
+                    ::capnp::word(20, 0, 0, 0, 2, 0, 1, 0),
+                    ::capnp::word(115, 105, 103, 0, 0, 0, 0, 0),
+                    ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ];
+                pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                    match index {
+                        0 => {
+                            <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect()
+                        }
+                        _ => panic!("invalid field index {}", index),
+                    }
+                }
+                pub fn get_annotation_types(
+                    child_index: Option<u16>,
+                    index: u32,
+                ) -> ::capnp::introspect::Type {
+                    panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+                }
+                pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                    ::capnp::introspect::RawStructSchema {
+                        encoded_node: &ENCODED_NODE,
+                        nonunion_members: NONUNION_MEMBERS,
+                        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    };
+                pub static NONUNION_MEMBERS: &[u16] = &[0];
+                pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+                pub const TYPE_ID: u64 = 0x90be_9e09_8380_9cf5;
+            }
         }
-        pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-          encoded_node: &ENCODED_NODE,
-          nonunion_members: NONUNION_MEMBERS,
-          members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-        };
-        pub static NONUNION_MEMBERS : &[u16] = &[0];
-        pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-        pub const TYPE_ID: u64 = 0x8c66_2509_2276_093d;
-      }
+
+        pub mod done_results {
+            #[derive(Copy, Clone)]
+            pub struct Owned(());
+            impl ::capnp::introspect::Introspect for Owned {
+                fn introspect() -> ::capnp::introspect::Type {
+                    ::capnp::introspect::TypeVariant::Struct(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    )
+                    .into()
+                }
+            }
+            impl ::capnp::traits::Owned for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::OwnedStruct for Owned {
+                type Reader<'a> = Reader<'a>;
+                type Builder<'a> = Builder<'a>;
+            }
+            impl ::capnp::traits::Pipelined for Owned {
+                type Pipeline = Pipeline;
+            }
+
+            pub struct Reader<'a> {
+                reader: ::capnp::private::layout::StructReader<'a>,
+            }
+            impl<'a> ::core::marker::Copy for Reader<'a> {}
+            impl<'a> ::core::clone::Clone for Reader<'a> {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+
+            impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+                fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                    Self { reader }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+                fn from(reader: Reader<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Reader::new(
+                        reader.reader,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::core::fmt::Debug for Reader<'a> {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                    core::fmt::Debug::fmt(
+                        &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                        f,
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+                fn get_from_pointer(
+                    reader: &::capnp::private::layout::PointerReader<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(reader.get_struct(default)?.into())
+                }
+            }
+
+            impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+                fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                    self.reader
+                }
+            }
+
+            impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+                fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                    self.reader
+                        .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+                }
+            }
+
+            impl<'a> Reader<'a> {
+                pub fn reborrow(&self) -> Reader<'_> {
+                    Self { ..*self }
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.reader.total_size()
+                }
+            }
+
+            pub struct Builder<'a> {
+                builder: ::capnp::private::layout::StructBuilder<'a>,
+            }
+            impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+                const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                    ::capnp::private::layout::StructSize {
+                        data: 0,
+                        pointers: 0,
+                    };
+            }
+            impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+                const TYPE_ID: u64 = _private::TYPE_ID;
+            }
+            impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+                fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                    Self { builder }
+                }
+            }
+
+            impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+                fn from(builder: Builder<'a>) -> Self {
+                    Self::Struct(::capnp::dynamic_struct::Builder::new(
+                        builder.builder,
+                        ::capnp::schema::StructSchema::new(
+                            ::capnp::introspect::RawBrandedStructSchema {
+                                generic: &_private::RAW_SCHEMA,
+                                field_types: _private::get_field_types,
+                                annotation_types: _private::get_annotation_types,
+                            },
+                        ),
+                    ))
+                }
+            }
+
+            impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+                fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                    self.builder
+                        .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+                }
+            }
+
+            impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+                fn init_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    _size: u32,
+                ) -> Self {
+                    builder
+                        .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                        .into()
+                }
+                fn get_from_pointer(
+                    builder: ::capnp::private::layout::PointerBuilder<'a>,
+                    default: ::core::option::Option<&'a [::capnp::Word]>,
+                ) -> ::capnp::Result<Self> {
+                    ::core::result::Result::Ok(
+                        builder
+                            .get_struct(
+                                <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                                default,
+                            )?
+                            .into(),
+                    )
+                }
+            }
+
+            impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+                fn set_pointer_builder(
+                    mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                    value: Self,
+                    canonicalize: bool,
+                ) -> ::capnp::Result<()> {
+                    pointer.set_struct(&value.reader, canonicalize)
+                }
+            }
+
+            impl<'a> Builder<'a> {
+                pub fn into_reader(self) -> Reader<'a> {
+                    self.builder.into_reader().into()
+                }
+                pub fn reborrow(&mut self) -> Builder<'_> {
+                    Builder {
+                        builder: self.builder.reborrow(),
+                    }
+                }
+                pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                    self.builder.as_reader().into()
+                }
+
+                pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                    self.builder.as_reader().total_size()
+                }
+            }
+
+            pub struct Pipeline {
+                _typeless: ::capnp::any_pointer::Pipeline,
+            }
+            impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+                fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                    Self {
+                        _typeless: typeless,
+                    }
+                }
+            }
+            impl Pipeline {}
+            mod _private {
+                pub static ENCODED_NODE: [::capnp::Word; 20] = [
+                    ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                    ::capnp::word(14, 192, 42, 250, 55, 69, 117, 205),
+                    ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(21, 0, 0, 0, 202, 1, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                    ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                    ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                    ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                    ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                    ::capnp::word(110, 115, 46, 67, 97, 108, 108, 98),
+                    ::capnp::word(97, 99, 107, 46, 100, 111, 110, 101),
+                    ::capnp::word(36, 82, 101, 115, 117, 108, 116, 115),
+                    ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ];
+                pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                    panic!("invalid field index {}", index)
+                }
+                pub fn get_annotation_types(
+                    child_index: Option<u16>,
+                    index: u32,
+                ) -> ::capnp::introspect::Type {
+                    panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+                }
+                pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                    ::capnp::introspect::RawStructSchema {
+                        encoded_node: &ENCODED_NODE,
+                        nonunion_members: NONUNION_MEMBERS,
+                        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                    };
+                pub static NONUNION_MEMBERS: &[u16] = &[];
+                pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+                pub const TYPE_ID: u64 = 0xcd75_4537_fa2a_c00e;
+            }
+        }
     }
 
-    pub mod write_results {
-      #[derive(Copy, Clone)]
-      pub struct Owned(());
-      impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-      impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-      pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-      impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-      impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-        fn clone(&self) -> Self { *self }
-      }
-
-      impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-        fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-          Self { reader,  }
-        }
-      }
-
-      impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-        fn from(reader: Reader<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-        }
-      }
-
-      impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-          core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-        }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(reader.get_struct(default)?.into())
-        }
-      }
-
-      impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-          self.reader
-        }
-      }
-
-      impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-          self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-        }
-      }
-
-      impl <'a,> Reader<'a,>  {
-        pub fn reborrow(&self) -> Reader<'_,> {
-          Self { .. *self }
-        }
-
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.reader.total_size()
-        }
-      }
-
-      pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-      impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-        const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 0 };
-      }
-      impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-        fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-          Self { builder,  }
-        }
-      }
-
-      impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-        fn from(builder: Builder<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-          self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-          builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-        }
-        fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-        }
-      }
-
-      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-      }
-
-      impl <'a,> Builder<'a,>  {
-        pub fn into_reader(self) -> Reader<'a,> {
-          self.builder.into_reader().into()
-        }
-        pub fn reborrow(&mut self) -> Builder<'_,> {
-          Builder { builder: self.builder.reborrow() }
-        }
-        pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          self.builder.as_reader().into()
-        }
-
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.builder.as_reader().total_size()
-        }
-      }
-
-      pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-      impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-          Self { _typeless: typeless,  }
-        }
-      }
-      impl Pipeline  {
-      }
-      mod _private {
-        pub static ENCODED_NODE: [::capnp::Word; 20] = [
-          ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-          ::capnp::word(229, 147, 206, 112, 112, 169, 183, 199),
-          ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(21, 0, 0, 0, 210, 1, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-          ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-          ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-          ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-          ::capnp::word(110, 115, 46, 67, 97, 108, 108, 98),
-          ::capnp::word(97, 99, 107, 46, 119, 114, 105, 116),
-          ::capnp::word(101, 36, 82, 101, 115, 117, 108, 116),
-          ::capnp::word(115, 0, 0, 0, 0, 0, 0, 0),
-        ];
-        pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-          panic!("invalid field index {}", index)
-        }
-        pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-          panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-        }
-        pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-          encoded_node: &ENCODED_NODE,
-          nonunion_members: NONUNION_MEMBERS,
-          members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-        };
-        pub static NONUNION_MEMBERS : &[u16] = &[];
-        pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-        pub const TYPE_ID: u64 = 0xc7b7_a970_70ce_93e5;
-      }
-    }
-
-    pub mod done_params {
-      #[derive(Copy, Clone)]
-      pub struct Owned(());
-      impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-      impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-      pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-      impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-      impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-        fn clone(&self) -> Self { *self }
-      }
-
-      impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-        fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-          Self { reader,  }
-        }
-      }
-
-      impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-        fn from(reader: Reader<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-        }
-      }
-
-      impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-          core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-        }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(reader.get_struct(default)?.into())
-        }
-      }
-
-      impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-          self.reader
-        }
-      }
-
-      impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-          self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-        }
-      }
-
-      impl <'a,> Reader<'a,>  {
-        pub fn reborrow(&self) -> Reader<'_,> {
-          Self { .. *self }
-        }
-
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.reader.total_size()
-        }
-        #[inline]
-        pub fn get_sig(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
-          ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn has_sig(&self) -> bool {
-          !self.reader.get_pointer_field(0).is_null()
-        }
-      }
-
-      pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-      impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-        const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
-      }
-      impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-        fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-          Self { builder,  }
-        }
-      }
-
-      impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-        fn from(builder: Builder<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-          self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-          builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-        }
-        fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-        }
-      }
-
-      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-      }
-
-      impl <'a,> Builder<'a,>  {
-        pub fn into_reader(self) -> Reader<'a,> {
-          self.builder.into_reader().into()
-        }
-        pub fn reborrow(&mut self) -> Builder<'_,> {
-          Builder { builder: self.builder.reborrow() }
-        }
-        pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          self.builder.as_reader().into()
-        }
-
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.builder.as_reader().total_size()
-        }
-        #[inline]
-        pub fn get_sig(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
-          ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-        }
-        #[inline]
-        pub fn set_sig(&mut self, value: ::capnp::data::Reader<'_>)  {
-          self.builder.reborrow().get_pointer_field(0).set_data(value);
-        }
-        #[inline]
-        pub fn init_sig(self, size: u32) -> ::capnp::data::Builder<'a> {
-          self.builder.get_pointer_field(0).init_data(size)
-        }
-        #[inline]
-        pub fn has_sig(&self) -> bool {
-          !self.builder.is_pointer_field_null(0)
-        }
-      }
-
-      pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-      impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-          Self { _typeless: typeless,  }
-        }
-      }
-      impl Pipeline  {
-      }
-      mod _private {
-        pub static ENCODED_NODE: [::capnp::Word; 35] = [
-          ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-          ::capnp::word(245, 156, 128, 131, 9, 158, 190, 144),
-          ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(21, 0, 0, 0, 194, 1, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(37, 0, 0, 0, 63, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-          ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-          ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-          ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-          ::capnp::word(110, 115, 46, 67, 97, 108, 108, 98),
-          ::capnp::word(97, 99, 107, 46, 100, 111, 110, 101),
-          ::capnp::word(36, 80, 97, 114, 97, 109, 115, 0),
-          ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(13, 0, 0, 0, 34, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
-          ::capnp::word(20, 0, 0, 0, 2, 0, 1, 0),
-          ::capnp::word(115, 105, 103, 0, 0, 0, 0, 0),
-          ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ];
-        pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-          match index {
-            0 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
-            _ => panic!("invalid field index {}", index),
-          }
-        }
-        pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-          panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-        }
-        pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-          encoded_node: &ENCODED_NODE,
-          nonunion_members: NONUNION_MEMBERS,
-          members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-        };
-        pub static NONUNION_MEMBERS : &[u16] = &[0];
-        pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-        pub const TYPE_ID: u64 = 0x90be_9e09_8380_9cf5;
-      }
-    }
-
-    pub mod done_results {
-      #[derive(Copy, Clone)]
-      pub struct Owned(());
-      impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-      impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-      impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-      pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-      impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-      impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-        fn clone(&self) -> Self { *self }
-      }
-
-      impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-        fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-          Self { reader,  }
-        }
-      }
-
-      impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-        fn from(reader: Reader<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-        }
-      }
-
-      impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-          core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-        }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-        fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(reader.get_struct(default)?.into())
-        }
-      }
-
-      impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-          self.reader
-        }
-      }
-
-      impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-          self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-        }
-      }
-
-      impl <'a,> Reader<'a,>  {
-        pub fn reborrow(&self) -> Reader<'_,> {
-          Self { .. *self }
-        }
-
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.reader.total_size()
-        }
-      }
-
-      pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-      impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-        const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 0 };
-      }
-      impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-        const TYPE_ID: u64 = _private::TYPE_ID;
-      }
-      impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-        fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-          Self { builder,  }
-        }
-      }
-
-      impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-        fn from(builder: Builder<'a,>) -> Self {
-          Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-          self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-        }
-      }
-
-      impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-        fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-          builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-        }
-        fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-          ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-        }
-      }
-
-      impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-        fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-      }
-
-      impl <'a,> Builder<'a,>  {
-        pub fn into_reader(self) -> Reader<'a,> {
-          self.builder.into_reader().into()
-        }
-        pub fn reborrow(&mut self) -> Builder<'_,> {
-          Builder { builder: self.builder.reborrow() }
-        }
-        pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-          self.builder.as_reader().into()
-        }
-
-        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-          self.builder.as_reader().total_size()
-        }
-      }
-
-      pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-      impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-          Self { _typeless: typeless,  }
-        }
-      }
-      impl Pipeline  {
-      }
-      mod _private {
-        pub static ENCODED_NODE: [::capnp::Word; 20] = [
-          ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-          ::capnp::word(14, 192, 42, 250, 55, 69, 117, 205),
-          ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(21, 0, 0, 0, 202, 1, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-          ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-          ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-          ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-          ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-          ::capnp::word(110, 115, 46, 67, 97, 108, 108, 98),
-          ::capnp::word(97, 99, 107, 46, 100, 111, 110, 101),
-          ::capnp::word(36, 82, 101, 115, 117, 108, 116, 115),
-          ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ];
-        pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-          panic!("invalid field index {}", index)
-        }
-        pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-          panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-        }
-        pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-          encoded_node: &ENCODED_NODE,
-          nonunion_members: NONUNION_MEMBERS,
-          members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-        };
-        pub static NONUNION_MEMBERS : &[u16] = &[];
-        pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-        pub const TYPE_ID: u64 = 0xcd75_4537_fa2a_c00e;
-      }
-    }
-  }
-
-  pub mod create_params {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
-    }
-
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_ns(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-      #[inline]
-      pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_rel(&self) -> bool {
-        !self.reader.get_pointer_field(1).is_null()
-      }
-      #[inline]
-      pub fn get_schema(self) -> ::capnp::Result<crate::schema::definitions_capnp::schema::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_schema(&self) -> bool {
-        !self.reader.get_pointer_field(2).is_null()
-      }
-      #[inline]
-      pub fn get_owner(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_owner(&self) -> bool {
-        !self.reader.get_pointer_field(3).is_null()
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 4 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_ns(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(0).set_text(value);
-      }
-      #[inline]
-      pub fn init_ns(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(0).init_text(size)
-      }
-      #[inline]
-      pub fn has_ns(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-      #[inline]
-      pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_rel(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(1).set_text(value);
-      }
-      #[inline]
-      pub fn init_rel(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(1).init_text(size)
-      }
-      #[inline]
-      pub fn has_rel(&self) -> bool {
-        !self.builder.is_pointer_field_null(1)
-      }
-      #[inline]
-      pub fn get_schema(self) -> ::capnp::Result<crate::schema::definitions_capnp::schema::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_schema(&mut self, value: crate::schema::definitions_capnp::schema::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(2), value, false)
-      }
-      #[inline]
-      pub fn init_schema(self, ) -> crate::schema::definitions_capnp::schema::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
-      }
-      #[inline]
-      pub fn has_schema(&self) -> bool {
-        !self.builder.is_pointer_field_null(2)
-      }
-      #[inline]
-      pub fn get_owner(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_owner(&mut self, value: ::capnp::data::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(3).set_data(value);
-      }
-      #[inline]
-      pub fn init_owner(self, size: u32) -> ::capnp::data::Builder<'a> {
-        self.builder.get_pointer_field(3).init_data(size)
-      }
-      #[inline]
-      pub fn has_owner(&self) -> bool {
-        !self.builder.is_pointer_field_null(3)
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-      pub fn get_schema(&self) -> crate::schema::definitions_capnp::schema::Pipeline {
-        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
-      }
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 80] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(228, 159, 237, 99, 71, 65, 134, 137),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(4, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 138, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(37, 0, 0, 0, 231, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 99, 114, 101, 97, 116),
-        ::capnp::word(101, 36, 80, 97, 114, 97, 109, 115),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(97, 0, 0, 0, 26, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(104, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(101, 0, 0, 0, 34, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(105, 0, 0, 0, 58, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(100, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(112, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(109, 0, 0, 0, 50, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(104, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(116, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(110, 115, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(114, 101, 108, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 0, 0),
-        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(67, 198, 188, 198, 149, 50, 198, 178),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(111, 119, 110, 101, 114, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
+    pub mod create_params {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_ns(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+            #[inline]
+            pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_rel(&self) -> bool {
+                !self.reader.get_pointer_field(1).is_null()
+            }
+            #[inline]
+            pub fn get_schema(
+                self,
+            ) -> ::capnp::Result<crate::schema::definitions_capnp::schema::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(2),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_schema(&self) -> bool {
+                !self.reader.get_pointer_field(2).is_null()
+            }
+            #[inline]
+            pub fn get_owner(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(3),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_owner(&self) -> bool {
+                !self.reader.get_pointer_field(3).is_null()
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 0,
+                    pointers: 4,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_ns(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(0).set_text(value);
+            }
+            #[inline]
+            pub fn init_ns(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(0).init_text(size)
+            }
+            #[inline]
+            pub fn has_ns(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+            #[inline]
+            pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_rel(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(1).set_text(value);
+            }
+            #[inline]
+            pub fn init_rel(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(1).init_text(size)
+            }
+            #[inline]
+            pub fn has_rel(&self) -> bool {
+                !self.builder.is_pointer_field_null(1)
+            }
+            #[inline]
+            pub fn get_schema(
+                self,
+            ) -> ::capnp::Result<crate::schema::definitions_capnp::schema::Builder<'a>>
+            {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(2),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_schema(
+                &mut self,
+                value: crate::schema::definitions_capnp::schema::Reader<'_>,
+            ) -> ::capnp::Result<()> {
+                ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.reborrow().get_pointer_field(2),
+                    value,
+                    false,
+                )
+            }
+            #[inline]
+            pub fn init_schema(self) -> crate::schema::definitions_capnp::schema::Builder<'a> {
+                ::capnp::traits::FromPointerBuilder::init_pointer(
+                    self.builder.get_pointer_field(2),
+                    0,
+                )
+            }
+            #[inline]
+            pub fn has_schema(&self) -> bool {
+                !self.builder.is_pointer_field_null(2)
+            }
+            #[inline]
+            pub fn get_owner(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(3),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_owner(&mut self, value: ::capnp::data::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(3).set_data(value);
+            }
+            #[inline]
+            pub fn init_owner(self, size: u32) -> ::capnp::data::Builder<'a> {
+                self.builder.get_pointer_field(3).init_data(size)
+            }
+            #[inline]
+            pub fn has_owner(&self) -> bool {
+                !self.builder.is_pointer_field_null(3)
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {
+            pub fn get_schema(&self) -> crate::schema::definitions_capnp::schema::Pipeline {
+                ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
+            }
+        }
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 80] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(228, 159, 237, 99, 71, 65, 134, 137),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(4, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 138, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(37, 0, 0, 0, 231, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 99, 114, 101, 97, 116),
+                ::capnp::word(101, 36, 80, 97, 114, 97, 109, 115),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(97, 0, 0, 0, 26, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(104, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(101, 0, 0, 0, 34, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(105, 0, 0, 0, 58, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(100, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(112, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(109, 0, 0, 0, 50, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(104, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(116, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(110, 115, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(114, 101, 108, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 0, 0),
+                ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(67, 198, 188, 198, 149, 50, 198, 178),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(111, 119, 110, 101, 114, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
           0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
           1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
           2 => <crate::schema::definitions_capnp::schema::Owned as ::capnp::introspect::Introspect>::introspect(),
           3 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
           _ => panic!("invalid field index {}", index),
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0x8986_4147_63ed_9fe4;
-    }
-  }
-
-  pub mod create_results {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
-    }
-
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_exists(self) -> bool {
-        self.reader.get_bool_field(0)
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 0 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_exists(self) -> bool {
-        self.builder.get_bool_field(0)
-      }
-      #[inline]
-      pub fn set_exists(&mut self, value: bool)  {
-        self.builder.set_bool_field(0, value);
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 35] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(75, 177, 187, 7, 130, 118, 9, 157),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 1, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 146, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(37, 0, 0, 0, 63, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 99, 114, 101, 97, 116),
-        ::capnp::word(101, 36, 82, 101, 115, 117, 108, 116),
-        ::capnp::word(115, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 58, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(20, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(101, 120, 105, 115, 116, 115, 0, 0),
-        ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
-          0 => <bool as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0x8986_4147_63ed_9fe4;
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0x9d09_7682_07bb_b14b;
-    }
-  }
-
-  pub mod push_params {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
     }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
+    pub mod create_results {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_exists(self) -> bool {
+                self.reader.get_bool_field(0)
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 1,
+                    pointers: 0,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_exists(self) -> bool {
+                self.builder.get_bool_field(0)
+            }
+            #[inline]
+            pub fn set_exists(&mut self, value: bool) {
+                self.builder.set_bool_field(0, value);
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 35] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(75, 177, 187, 7, 130, 118, 9, 157),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 1, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 146, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(37, 0, 0, 0, 63, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 99, 114, 101, 97, 116),
+                ::capnp::word(101, 36, 82, 101, 115, 117, 108, 116),
+                ::capnp::word(115, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 58, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(20, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(101, 120, 105, 115, 116, 115, 0, 0),
+                ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
+                    0 => <bool as ::capnp::introspect::Introspect>::introspect(),
+                    _ => panic!("invalid field index {}", index),
+                }
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0x9d09_7682_07bb_b14b;
+        }
     }
 
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
+    pub mod push_params {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
 
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
 
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_ns(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-      #[inline]
-      pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_rel(&self) -> bool {
-        !self.reader.get_pointer_field(1).is_null()
-      }
-      #[inline]
-      pub fn get_tx(self) -> ::capnp::Result<crate::schema::definitions_capnp::tx::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_tx(&self) -> bool {
-        !self.reader.get_pointer_field(2).is_null()
-      }
-      #[inline]
-      pub fn get_sig(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_sig(&self) -> bool {
-        !self.reader.get_pointer_field(3).is_null()
-      }
-    }
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 4 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
 
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_ns(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+            #[inline]
+            pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_rel(&self) -> bool {
+                !self.reader.get_pointer_field(1).is_null()
+            }
+            #[inline]
+            pub fn get_tx(
+                self,
+            ) -> ::capnp::Result<crate::schema::definitions_capnp::tx::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(2),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_tx(&self) -> bool {
+                !self.reader.get_pointer_field(2).is_null()
+            }
+            #[inline]
+            pub fn get_sig(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(3),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_sig(&self) -> bool {
+                !self.reader.get_pointer_field(3).is_null()
+            }
+        }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 0,
+                    pointers: 4,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
 
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_ns(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(0).set_text(value);
-      }
-      #[inline]
-      pub fn init_ns(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(0).init_text(size)
-      }
-      #[inline]
-      pub fn has_ns(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-      #[inline]
-      pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_rel(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(1).set_text(value);
-      }
-      #[inline]
-      pub fn init_rel(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(1).init_text(size)
-      }
-      #[inline]
-      pub fn has_rel(&self) -> bool {
-        !self.builder.is_pointer_field_null(1)
-      }
-      #[inline]
-      pub fn get_tx(self) -> ::capnp::Result<crate::schema::definitions_capnp::tx::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_tx(&mut self, value: crate::schema::definitions_capnp::tx::Reader<'_>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(2), value, false)
-      }
-      #[inline]
-      pub fn init_tx(self, ) -> crate::schema::definitions_capnp::tx::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
-      }
-      #[inline]
-      pub fn has_tx(&self) -> bool {
-        !self.builder.is_pointer_field_null(2)
-      }
-      #[inline]
-      pub fn get_sig(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_sig(&mut self, value: ::capnp::data::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(3).set_data(value);
-      }
-      #[inline]
-      pub fn init_sig(self, size: u32) -> ::capnp::data::Builder<'a> {
-        self.builder.get_pointer_field(3).init_data(size)
-      }
-      #[inline]
-      pub fn has_sig(&self) -> bool {
-        !self.builder.is_pointer_field_null(3)
-      }
-    }
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-      pub fn get_tx(&self) -> crate::schema::definitions_capnp::tx::Pipeline {
-        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
-      }
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 79] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(217, 209, 129, 7, 186, 16, 207, 133),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(4, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 122, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(33, 0, 0, 0, 231, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 112, 117, 115, 104, 36),
-        ::capnp::word(80, 97, 114, 97, 109, 115, 0, 0),
-        ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(97, 0, 0, 0, 26, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(104, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(101, 0, 0, 0, 34, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(105, 0, 0, 0, 26, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(100, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(112, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(109, 0, 0, 0, 34, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(104, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(116, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(110, 115, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(114, 101, 108, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(116, 120, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(95, 249, 117, 29, 7, 93, 19, 233),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 105, 103, 0, 0, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_ns(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(0).set_text(value);
+            }
+            #[inline]
+            pub fn init_ns(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(0).init_text(size)
+            }
+            #[inline]
+            pub fn has_ns(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+            #[inline]
+            pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_rel(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(1).set_text(value);
+            }
+            #[inline]
+            pub fn init_rel(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(1).init_text(size)
+            }
+            #[inline]
+            pub fn has_rel(&self) -> bool {
+                !self.builder.is_pointer_field_null(1)
+            }
+            #[inline]
+            pub fn get_tx(
+                self,
+            ) -> ::capnp::Result<crate::schema::definitions_capnp::tx::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(2),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_tx(
+                &mut self,
+                value: crate::schema::definitions_capnp::tx::Reader<'_>,
+            ) -> ::capnp::Result<()> {
+                ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.reborrow().get_pointer_field(2),
+                    value,
+                    false,
+                )
+            }
+            #[inline]
+            pub fn init_tx(self) -> crate::schema::definitions_capnp::tx::Builder<'a> {
+                ::capnp::traits::FromPointerBuilder::init_pointer(
+                    self.builder.get_pointer_field(2),
+                    0,
+                )
+            }
+            #[inline]
+            pub fn has_tx(&self) -> bool {
+                !self.builder.is_pointer_field_null(2)
+            }
+            #[inline]
+            pub fn get_sig(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(3),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_sig(&mut self, value: ::capnp::data::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(3).set_data(value);
+            }
+            #[inline]
+            pub fn init_sig(self, size: u32) -> ::capnp::data::Builder<'a> {
+                self.builder.get_pointer_field(3).init_data(size)
+            }
+            #[inline]
+            pub fn has_sig(&self) -> bool {
+                !self.builder.is_pointer_field_null(3)
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {
+            pub fn get_tx(&self) -> crate::schema::definitions_capnp::tx::Pipeline {
+                ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
+            }
+        }
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 79] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(217, 209, 129, 7, 186, 16, 207, 133),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(4, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 122, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(33, 0, 0, 0, 231, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 112, 117, 115, 104, 36),
+                ::capnp::word(80, 97, 114, 97, 109, 115, 0, 0),
+                ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(97, 0, 0, 0, 26, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(104, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(101, 0, 0, 0, 34, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(105, 0, 0, 0, 26, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(100, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(112, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(3, 0, 0, 0, 3, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(109, 0, 0, 0, 34, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(104, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(116, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(110, 115, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(114, 101, 108, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(116, 120, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(95, 249, 117, 29, 7, 93, 19, 233),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 105, 103, 0, 0, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
           0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
           1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
           2 => <crate::schema::definitions_capnp::tx::Owned as ::capnp::introspect::Introspect>::introspect(),
           3 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
           _ => panic!("invalid field index {}", index),
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0x85cf_10ba_0781_d1d9;
-    }
-  }
-
-  pub mod push_results {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
-    }
-
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 0 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 18] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(189, 41, 246, 159, 216, 51, 123, 223),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 130, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 112, 117, 115, 104, 36),
-        ::capnp::word(82, 101, 115, 117, 108, 116, 115, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        panic!("invalid field index {}", index)
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0xdf7b_33d8_9ff6_29bd;
-    }
-  }
-
-  pub mod upload_params {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
-    }
-
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_ns(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-      #[inline]
-      pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_rel(&self) -> bool {
-        !self.reader.get_pointer_field(1).is_null()
-      }
-      #[inline]
-      pub fn get_size(self) -> u64 {
-        self.reader.get_data_field::<u64>(0)
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 2 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_ns(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(0).set_text(value);
-      }
-      #[inline]
-      pub fn init_ns(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(0).init_text(size)
-      }
-      #[inline]
-      pub fn has_ns(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-      #[inline]
-      pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_rel(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(1).set_text(value);
-      }
-      #[inline]
-      pub fn init_rel(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(1).init_text(size)
-      }
-      #[inline]
-      pub fn has_rel(&self) -> bool {
-        !self.builder.is_pointer_field_null(1)
-      }
-      #[inline]
-      pub fn get_size(self) -> u64 {
-        self.builder.get_data_field::<u64>(0)
-      }
-      #[inline]
-      pub fn set_size(&mut self, value: u64)  {
-        self.builder.set_data_field::<u64>(0, value);
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 65] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(202, 11, 186, 171, 136, 184, 103, 208),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 1, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 138, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(37, 0, 0, 0, 175, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 117, 112, 108, 111, 97),
-        ::capnp::word(100, 36, 80, 97, 114, 97, 109, 115),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(69, 0, 0, 0, 26, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(64, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(76, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(73, 0, 0, 0, 34, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(68, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(80, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(77, 0, 0, 0, 42, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(72, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(84, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(110, 115, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(114, 101, 108, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 105, 122, 101, 0, 0, 0, 0),
-        ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
-          0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          2 => <u64 as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0x85cf_10ba_0781_d1d9;
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0xd067_b888_abba_0bca;
-    }
-  }
-
-  pub mod upload_results {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
     }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
+    pub mod push_results {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 0,
+                    pointers: 0,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 18] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(189, 41, 246, 159, 216, 51, 123, 223),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 130, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 112, 117, 115, 104, 36),
+                ::capnp::word(82, 101, 115, 117, 108, 116, 115, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                panic!("invalid field index {}", index)
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0xdf7b_33d8_9ff6_29bd;
+        }
     }
 
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
+    pub mod upload_params {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_ns(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+            #[inline]
+            pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_rel(&self) -> bool {
+                !self.reader.get_pointer_field(1).is_null()
+            }
+            #[inline]
+            pub fn get_size(self) -> u64 {
+                self.reader.get_data_field::<u64>(0)
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 1,
+                    pointers: 2,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_ns(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(0).set_text(value);
+            }
+            #[inline]
+            pub fn init_ns(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(0).init_text(size)
+            }
+            #[inline]
+            pub fn has_ns(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+            #[inline]
+            pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_rel(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(1).set_text(value);
+            }
+            #[inline]
+            pub fn init_rel(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(1).init_text(size)
+            }
+            #[inline]
+            pub fn has_rel(&self) -> bool {
+                !self.builder.is_pointer_field_null(1)
+            }
+            #[inline]
+            pub fn get_size(self) -> u64 {
+                self.builder.get_data_field::<u64>(0)
+            }
+            #[inline]
+            pub fn set_size(&mut self, value: u64) {
+                self.builder.set_data_field::<u64>(0, value);
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 65] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(202, 11, 186, 171, 136, 184, 103, 208),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 1, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 138, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(37, 0, 0, 0, 175, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 117, 112, 108, 111, 97),
+                ::capnp::word(100, 36, 80, 97, 114, 97, 109, 115),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(69, 0, 0, 0, 26, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(64, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(76, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(73, 0, 0, 0, 34, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(68, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(80, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(77, 0, 0, 0, 42, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(72, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(84, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(110, 115, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(114, 101, 108, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 105, 122, 101, 0, 0, 0, 0),
+                ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
+                    0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    2 => <u64 as ::capnp::introspect::Introspect>::introspect(),
+                    _ => panic!("invalid field index {}", index),
+                }
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0xd067_b888_abba_0bca;
+        }
     }
 
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
+    pub mod upload_results {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
 
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
 
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
 
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_callback(self) -> ::capnp::Result<crate::schema::provider_capnp::publications::callback::Client> {
-        match self.reader.get_pointer_field(0).get_capability() { ::core::result::Result::Ok(c) => ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(c)), ::core::result::Result::Err(e) => ::core::result::Result::Err(e)}
-      }
-      #[inline]
-      pub fn has_callback(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-    }
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
 
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
 
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
 
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
 
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_callback(
+                self,
+            ) -> ::capnp::Result<crate::schema::provider_capnp::publications::callback::Client>
+            {
+                match self.reader.get_pointer_field(0).get_capability() {
+                    ::core::result::Result::Ok(c) => {
+                        ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(c))
+                    }
+                    ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+                }
+            }
+            #[inline]
+            pub fn has_callback(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+        }
 
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 0,
+                    pointers: 1,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
 
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
 
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_callback(self) -> ::capnp::Result<crate::schema::provider_capnp::publications::callback::Client> {
-        match self.builder.get_pointer_field(0).get_capability() { ::core::result::Result::Ok(c) => ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(c)), ::core::result::Result::Err(e) => ::core::result::Result::Err(e)}
-      }
-      #[inline]
-      pub fn set_callback(&mut self, value: crate::schema::provider_capnp::publications::callback::Client)  {
-        self.builder.reborrow().get_pointer_field(0).set_capability(value.client.hook);
-      }
-      #[inline]
-      pub fn has_callback(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-    }
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-      pub fn get_callback(&self) -> crate::schema::provider_capnp::publications::callback::Client {
-        ::capnp::capability::FromClientHook::new(self._typeless.get_pointer_field(0).as_cap())
-      }
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 36] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(49, 247, 176, 59, 98, 190, 34, 212),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 146, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(37, 0, 0, 0, 63, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 117, 112, 108, 111, 97),
-        ::capnp::word(100, 36, 82, 101, 115, 117, 108, 116),
-        ::capnp::word(115, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 74, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(24, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(99, 97, 108, 108, 98, 97, 99, 107),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(17, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(144, 177, 3, 52, 226, 138, 146, 180),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(17, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_callback(
+                self,
+            ) -> ::capnp::Result<crate::schema::provider_capnp::publications::callback::Client>
+            {
+                match self.builder.get_pointer_field(0).get_capability() {
+                    ::core::result::Result::Ok(c) => {
+                        ::core::result::Result::Ok(::capnp::capability::FromClientHook::new(c))
+                    }
+                    ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+                }
+            }
+            #[inline]
+            pub fn set_callback(
+                &mut self,
+                value: crate::schema::provider_capnp::publications::callback::Client,
+            ) {
+                self.builder
+                    .reborrow()
+                    .get_pointer_field(0)
+                    .set_capability(value.client.hook);
+            }
+            #[inline]
+            pub fn has_callback(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {
+            pub fn get_callback(
+                &self,
+            ) -> crate::schema::provider_capnp::publications::callback::Client {
+                ::capnp::capability::FromClientHook::new(
+                    self._typeless.get_pointer_field(0).as_cap(),
+                )
+            }
+        }
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 36] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(49, 247, 176, 59, 98, 190, 34, 212),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 146, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(37, 0, 0, 0, 63, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 117, 112, 108, 111, 97),
+                ::capnp::word(100, 36, 82, 101, 115, 117, 108, 116),
+                ::capnp::word(115, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 74, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(24, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(99, 97, 108, 108, 98, 97, 99, 107),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(17, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(144, 177, 3, 52, 226, 138, 146, 180),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(17, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
           0 => <crate::schema::provider_capnp::publications::callback::Owned as ::capnp::introspect::Introspect>::introspect(),
           _ => panic!("invalid field index {}", index),
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0xd422_be62_3bb0_f731;
-    }
-  }
-
-  pub mod list_params {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
-    }
-
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_owner(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_owner(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_owner(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_owner(&mut self, value: ::capnp::data::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(0).set_data(value);
-      }
-      #[inline]
-      pub fn init_owner(self, size: u32) -> ::capnp::data::Builder<'a> {
-        self.builder.get_pointer_field(0).init_data(size)
-      }
-      #[inline]
-      pub fn has_owner(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 34] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(104, 96, 252, 120, 65, 152, 2, 162),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 122, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(33, 0, 0, 0, 63, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 108, 105, 115, 116, 36),
-        ::capnp::word(80, 97, 114, 97, 109, 115, 0, 0),
-        ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 50, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(20, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(111, 119, 110, 101, 114, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
-          0 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0xd422_be62_3bb0_f731;
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0xa202_9841_78fc_6068;
-    }
-  }
-
-  pub mod list_results {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
     }
 
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_publications(self) -> ::capnp::Result<::capnp::text_list::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_publications(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_publications(self) -> ::capnp::Result<::capnp::text_list::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_publications(&mut self, value: ::capnp::text_list::Reader<'a>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
-      }
-      #[inline]
-      pub fn init_publications(self, size: u32) -> ::capnp::text_list::Builder<'a> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
-      }
-      #[inline]
-      pub fn has_publications(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 39] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(252, 113, 87, 150, 169, 242, 29, 236),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 130, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(33, 0, 0, 0, 63, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 108, 105, 115, 116, 36),
-        ::capnp::word(82, 101, 115, 117, 108, 116, 115, 0),
-        ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 106, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(40, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(112, 117, 98, 108, 105, 99, 97, 116),
-        ::capnp::word(105, 111, 110, 115, 0, 0, 0, 0),
-        ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
-          0 => <::capnp::text_list::Owned as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
+    pub mod list_params {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0xec1d_f2a9_9657_71fc;
-    }
-  }
-
-  pub mod deals_params {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
-    }
-
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_ns(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-      #[inline]
-      pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_rel(&self) -> bool {
-        !self.reader.get_pointer_field(1).is_null()
-      }
-      #[inline]
-      pub fn get_limit(self) -> u32 {
-        self.reader.get_data_field::<u32>(0)
-      }
-      #[inline]
-      pub fn get_offset(self) -> u64 {
-        self.reader.get_data_field::<u64>(1)
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 2 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_ns(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(0).set_text(value);
-      }
-      #[inline]
-      pub fn init_ns(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(0).init_text(size)
-      }
-      #[inline]
-      pub fn has_ns(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-      #[inline]
-      pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_rel(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(1).set_text(value);
-      }
-      #[inline]
-      pub fn init_rel(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(1).init_text(size)
-      }
-      #[inline]
-      pub fn has_rel(&self) -> bool {
-        !self.builder.is_pointer_field_null(1)
-      }
-      #[inline]
-      pub fn get_limit(self) -> u32 {
-        self.builder.get_data_field::<u32>(0)
-      }
-      #[inline]
-      pub fn set_limit(&mut self, value: u32)  {
-        self.builder.set_data_field::<u32>(0, value);
-      }
-      #[inline]
-      pub fn get_offset(self) -> u64 {
-        self.builder.get_data_field::<u64>(1)
-      }
-      #[inline]
-      pub fn set_offset(&mut self, value: u64)  {
-        self.builder.set_data_field::<u64>(1, value);
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 79] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(174, 212, 11, 232, 94, 173, 155, 136),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 2, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 130, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(33, 0, 0, 0, 231, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 100, 101, 97, 108, 115),
-        ::capnp::word(36, 80, 97, 114, 97, 109, 115, 0),
-        ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(97, 0, 0, 0, 26, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(104, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(101, 0, 0, 0, 34, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(105, 0, 0, 0, 50, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(100, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(112, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(3, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(109, 0, 0, 0, 58, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(104, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(116, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(110, 115, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(114, 101, 108, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(108, 105, 109, 105, 116, 0, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(111, 102, 102, 115, 101, 116, 0, 0),
-        ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
-          0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          2 => <u32 as ::capnp::introspect::Introspect>::introspect(),
-          3 => <u64 as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0x889b_ad5e_e80b_d4ae;
-    }
-  }
-
-  pub mod deals_results {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
-    }
-
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_deals(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::deal_info::Owned>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_deals(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_deals(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::deal_info::Owned>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_deals(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::deal_info::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
-      }
-      #[inline]
-      pub fn init_deals(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::deal_info::Owned> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
-      }
-      #[inline]
-      pub fn has_deals(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 39] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(104, 28, 60, 203, 231, 120, 14, 139),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 138, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(37, 0, 0, 0, 63, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 100, 101, 97, 108, 115),
-        ::capnp::word(36, 82, 101, 115, 117, 108, 116, 115),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 50, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(36, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(100, 101, 97, 108, 115, 0, 0, 0),
-        ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(134, 40, 187, 117, 196, 247, 155, 198),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
-          0 => <::capnp::struct_list::Owned<crate::schema::definitions_capnp::deal_info::Owned> as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0x8b0e_78e7_cb3c_1c68;
-    }
-  }
-
-  pub mod latest_deals_params {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
-    }
-
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_ns(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-      #[inline]
-      pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_rel(&self) -> bool {
-        !self.reader.get_pointer_field(1).is_null()
-      }
-      #[inline]
-      pub fn get_n(self) -> u32 {
-        self.reader.get_data_field::<u32>(0)
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 2 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_ns(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(0).set_text(value);
-      }
-      #[inline]
-      pub fn init_ns(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(0).init_text(size)
-      }
-      #[inline]
-      pub fn has_ns(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-      #[inline]
-      pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_rel(&mut self, value: ::capnp::text::Reader<'_>)  {
-        self.builder.reborrow().get_pointer_field(1).set_text(value);
-      }
-      #[inline]
-      pub fn init_rel(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.get_pointer_field(1).init_text(size)
-      }
-      #[inline]
-      pub fn has_rel(&self) -> bool {
-        !self.builder.is_pointer_field_null(1)
-      }
-      #[inline]
-      pub fn get_n(self) -> u32 {
-        self.builder.get_data_field::<u32>(0)
-      }
-      #[inline]
-      pub fn set_n(&mut self, value: u32)  {
-        self.builder.set_data_field::<u32>(0, value);
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 65] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(23, 180, 105, 6, 46, 98, 182, 144),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 1, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 178, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(37, 0, 0, 0, 175, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 108, 97, 116, 101, 115),
-        ::capnp::word(116, 68, 101, 97, 108, 115, 36, 80),
-        ::capnp::word(97, 114, 97, 109, 115, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(69, 0, 0, 0, 26, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(64, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(76, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(73, 0, 0, 0, 34, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(68, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(80, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(77, 0, 0, 0, 18, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(72, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(84, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(110, 115, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(114, 101, 108, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(110, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
-          0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          2 => <u32 as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0x90b6_622e_0669_b417;
-    }
-  }
 
-  pub mod latest_deals_results {
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <'a,> ::core::marker::Copy for Reader<'a,>  {}
-    impl <'a,> ::core::clone::Clone for Reader<'a,>  {
-      fn clone(&self) -> Self { *self }
-    }
-
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::core::fmt::Debug for Reader<'a,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn get_deals(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::deal_info::Owned>> {
-        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn has_deals(&self) -> bool {
-        !self.reader.get_pointer_field(0).is_null()
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 1 };
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder for Reader<'a,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn get_deals(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::deal_info::Owned>> {
-        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-      }
-      #[inline]
-      pub fn set_deals(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema::definitions_capnp::deal_info::Owned>) -> ::capnp::Result<()> {
-        ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
-      }
-      #[inline]
-      pub fn init_deals(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::schema::definitions_capnp::deal_info::Owned> {
-        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
-      }
-      #[inline]
-      pub fn has_deals(&self) -> bool {
-        !self.builder.is_pointer_field_null(0)
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 39] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(184, 22, 83, 45, 211, 54, 218, 231),
-        ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 186, 1, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(37, 0, 0, 0, 63, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
-        ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
-        ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
-        ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
-        ::capnp::word(110, 115, 46, 108, 97, 116, 101, 115),
-        ::capnp::word(116, 68, 101, 97, 108, 115, 36, 82),
-        ::capnp::word(101, 115, 117, 108, 116, 115, 0, 0),
-        ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(13, 0, 0, 0, 50, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(36, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(100, 101, 97, 108, 115, 0, 0, 0),
-        ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(134, 40, 187, 117, 196, 247, 155, 198),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
-          0 => <::capnp::struct_list::Owned<crate::schema::definitions_capnp::deal_info::Owned> as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
         }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[0];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub const TYPE_ID: u64 = 0xe7da_36d3_2d53_16b8;
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_owner(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_owner(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 0,
+                    pointers: 1,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_owner(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_owner(&mut self, value: ::capnp::data::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(0).set_data(value);
+            }
+            #[inline]
+            pub fn init_owner(self, size: u32) -> ::capnp::data::Builder<'a> {
+                self.builder.get_pointer_field(0).init_data(size)
+            }
+            #[inline]
+            pub fn has_owner(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 34] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(104, 96, 252, 120, 65, 152, 2, 162),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 122, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(33, 0, 0, 0, 63, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 108, 105, 115, 116, 36),
+                ::capnp::word(80, 97, 114, 97, 109, 115, 0, 0),
+                ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 50, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(20, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(111, 119, 110, 101, 114, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
+                    0 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    _ => panic!("invalid field index {}", index),
+                }
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0xa202_9841_78fc_6068;
+        }
     }
-  }
+
+    pub mod list_results {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_publications(self) -> ::capnp::Result<::capnp::text_list::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_publications(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 0,
+                    pointers: 1,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_publications(self) -> ::capnp::Result<::capnp::text_list::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_publications(
+                &mut self,
+                value: ::capnp::text_list::Reader<'a>,
+            ) -> ::capnp::Result<()> {
+                ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.reborrow().get_pointer_field(0),
+                    value,
+                    false,
+                )
+            }
+            #[inline]
+            pub fn init_publications(self, size: u32) -> ::capnp::text_list::Builder<'a> {
+                ::capnp::traits::FromPointerBuilder::init_pointer(
+                    self.builder.get_pointer_field(0),
+                    size,
+                )
+            }
+            #[inline]
+            pub fn has_publications(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 39] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(252, 113, 87, 150, 169, 242, 29, 236),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 130, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(33, 0, 0, 0, 63, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 108, 105, 115, 116, 36),
+                ::capnp::word(82, 101, 115, 117, 108, 116, 115, 0),
+                ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 106, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(40, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(112, 117, 98, 108, 105, 99, 97, 116),
+                ::capnp::word(105, 111, 110, 115, 0, 0, 0, 0),
+                ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
+                    0 => {
+                        <::capnp::text_list::Owned as ::capnp::introspect::Introspect>::introspect()
+                    }
+                    _ => panic!("invalid field index {}", index),
+                }
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0xec1d_f2a9_9657_71fc;
+        }
+    }
+
+    pub mod deals_params {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_ns(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+            #[inline]
+            pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_rel(&self) -> bool {
+                !self.reader.get_pointer_field(1).is_null()
+            }
+            #[inline]
+            pub fn get_limit(self) -> u32 {
+                self.reader.get_data_field::<u32>(0)
+            }
+            #[inline]
+            pub fn get_offset(self) -> u64 {
+                self.reader.get_data_field::<u64>(1)
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 2,
+                    pointers: 2,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_ns(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(0).set_text(value);
+            }
+            #[inline]
+            pub fn init_ns(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(0).init_text(size)
+            }
+            #[inline]
+            pub fn has_ns(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+            #[inline]
+            pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_rel(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(1).set_text(value);
+            }
+            #[inline]
+            pub fn init_rel(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(1).init_text(size)
+            }
+            #[inline]
+            pub fn has_rel(&self) -> bool {
+                !self.builder.is_pointer_field_null(1)
+            }
+            #[inline]
+            pub fn get_limit(self) -> u32 {
+                self.builder.get_data_field::<u32>(0)
+            }
+            #[inline]
+            pub fn set_limit(&mut self, value: u32) {
+                self.builder.set_data_field::<u32>(0, value);
+            }
+            #[inline]
+            pub fn get_offset(self) -> u64 {
+                self.builder.get_data_field::<u64>(1)
+            }
+            #[inline]
+            pub fn set_offset(&mut self, value: u64) {
+                self.builder.set_data_field::<u64>(1, value);
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 79] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(174, 212, 11, 232, 94, 173, 155, 136),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 2, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 130, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(33, 0, 0, 0, 231, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 100, 101, 97, 108, 115),
+                ::capnp::word(36, 80, 97, 114, 97, 109, 115, 0),
+                ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(97, 0, 0, 0, 26, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(92, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(104, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(101, 0, 0, 0, 34, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(105, 0, 0, 0, 50, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(100, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(112, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(3, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(109, 0, 0, 0, 58, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(104, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(116, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(110, 115, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(114, 101, 108, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(108, 105, 109, 105, 116, 0, 0, 0),
+                ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(111, 102, 102, 115, 101, 116, 0, 0),
+                ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
+                    0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    2 => <u32 as ::capnp::introspect::Introspect>::introspect(),
+                    3 => <u64 as ::capnp::introspect::Introspect>::introspect(),
+                    _ => panic!("invalid field index {}", index),
+                }
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2, 3];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0x889b_ad5e_e80b_d4ae;
+        }
+    }
+
+    pub mod deals_results {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_deals(
+                self,
+            ) -> ::capnp::Result<
+                ::capnp::struct_list::Reader<
+                    'a,
+                    crate::schema::definitions_capnp::deal_info::Owned,
+                >,
+            > {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_deals(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 0,
+                    pointers: 1,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_deals(
+                self,
+            ) -> ::capnp::Result<
+                ::capnp::struct_list::Builder<
+                    'a,
+                    crate::schema::definitions_capnp::deal_info::Owned,
+                >,
+            > {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_deals(
+                &mut self,
+                value: ::capnp::struct_list::Reader<
+                    'a,
+                    crate::schema::definitions_capnp::deal_info::Owned,
+                >,
+            ) -> ::capnp::Result<()> {
+                ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.reborrow().get_pointer_field(0),
+                    value,
+                    false,
+                )
+            }
+            #[inline]
+            pub fn init_deals(
+                self,
+                size: u32,
+            ) -> ::capnp::struct_list::Builder<'a, crate::schema::definitions_capnp::deal_info::Owned>
+            {
+                ::capnp::traits::FromPointerBuilder::init_pointer(
+                    self.builder.get_pointer_field(0),
+                    size,
+                )
+            }
+            #[inline]
+            pub fn has_deals(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 39] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(104, 28, 60, 203, 231, 120, 14, 139),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 138, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(37, 0, 0, 0, 63, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 100, 101, 97, 108, 115),
+                ::capnp::word(36, 82, 101, 115, 117, 108, 116, 115),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 50, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(36, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(100, 101, 97, 108, 115, 0, 0, 0),
+                ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(134, 40, 187, 117, 196, 247, 155, 198),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
+                    0 => <::capnp::struct_list::Owned<
+                        crate::schema::definitions_capnp::deal_info::Owned,
+                    > as ::capnp::introspect::Introspect>::introspect(),
+                    _ => panic!("invalid field index {}", index),
+                }
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0x8b0e_78e7_cb3c_1c68;
+        }
+    }
+
+    pub mod latest_deals_params {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_ns(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+            #[inline]
+            pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_rel(&self) -> bool {
+                !self.reader.get_pointer_field(1).is_null()
+            }
+            #[inline]
+            pub fn get_n(self) -> u32 {
+                self.reader.get_data_field::<u32>(0)
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 1,
+                    pointers: 2,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_ns(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_ns(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(0).set_text(value);
+            }
+            #[inline]
+            pub fn init_ns(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(0).init_text(size)
+            }
+            #[inline]
+            pub fn has_ns(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+            #[inline]
+            pub fn get_rel(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_rel(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.reborrow().get_pointer_field(1).set_text(value);
+            }
+            #[inline]
+            pub fn init_rel(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(1).init_text(size)
+            }
+            #[inline]
+            pub fn has_rel(&self) -> bool {
+                !self.builder.is_pointer_field_null(1)
+            }
+            #[inline]
+            pub fn get_n(self) -> u32 {
+                self.builder.get_data_field::<u32>(0)
+            }
+            #[inline]
+            pub fn set_n(&mut self, value: u32) {
+                self.builder.set_data_field::<u32>(0, value);
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 65] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(23, 180, 105, 6, 46, 98, 182, 144),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 1, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 178, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(37, 0, 0, 0, 175, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 108, 97, 116, 101, 115),
+                ::capnp::word(116, 68, 101, 97, 108, 115, 36, 80),
+                ::capnp::word(97, 114, 97, 109, 115, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(69, 0, 0, 0, 26, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(64, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(76, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(73, 0, 0, 0, 34, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(68, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(80, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(77, 0, 0, 0, 18, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(72, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(84, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(110, 115, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(114, 101, 108, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(110, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
+                    0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    1 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+                    2 => <u32 as ::capnp::introspect::Introspect>::introspect(),
+                    _ => panic!("invalid field index {}", index),
+                }
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0, 1, 2];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0x90b6_622e_0669_b417;
+        }
+    }
+
+    pub mod latest_deals_results {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl ::capnp::introspect::Introspect for Owned {
+            fn introspect() -> ::capnp::introspect::Type {
+                ::capnp::introspect::TypeVariant::Struct(
+                    ::capnp::introspect::RawBrandedStructSchema {
+                        generic: &_private::RAW_SCHEMA,
+                        field_types: _private::get_field_types,
+                        annotation_types: _private::get_annotation_types,
+                    },
+                )
+                .into()
+            }
+        }
+        impl ::capnp::traits::Owned for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::OwnedStruct for Owned {
+            type Reader<'a> = Reader<'a>;
+            type Builder<'a> = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+        impl<'a> ::core::marker::Copy for Reader<'a> {}
+        impl<'a> ::core::clone::Clone for Reader<'a> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a> {
+            fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+                Self { reader }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Reader<'a>> for ::capnp::dynamic_value::Reader<'a> {
+            fn from(reader: Reader<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Reader::new(
+                    reader.reader,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::core::fmt::Debug for Reader<'a> {
+            fn fmt(
+                &self,
+                f: &mut ::core::fmt::Formatter<'_>,
+            ) -> ::core::result::Result<(), ::core::fmt::Error> {
+                core::fmt::Debug::fmt(
+                    &::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self),
+                    f,
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(reader.get_struct(default)?.into())
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Self { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_deals(
+                self,
+            ) -> ::capnp::Result<
+                ::capnp::struct_list::Reader<
+                    'a,
+                    crate::schema::definitions_capnp::deal_info::Owned,
+                >,
+            > {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_deals(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            const STRUCT_SIZE: ::capnp::private::layout::StructSize =
+                ::capnp::private::layout::StructSize {
+                    data: 0,
+                    pointers: 1,
+                };
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            const TYPE_ID: u64 = _private::TYPE_ID;
+        }
+        impl<'a> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a> {
+            fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+                Self { builder }
+            }
+        }
+
+        impl<'a> ::core::convert::From<Builder<'a>> for ::capnp::dynamic_value::Builder<'a> {
+            fn from(builder: Builder<'a>) -> Self {
+                Self::Struct(::capnp::dynamic_struct::Builder::new(
+                    builder.builder,
+                    ::capnp::schema::StructSchema::new(
+                        ::capnp::introspect::RawBrandedStructSchema {
+                            generic: &_private::RAW_SCHEMA,
+                            field_types: _private::get_field_types,
+                            annotation_types: _private::get_annotation_types,
+                        },
+                    ),
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Self {
+                builder
+                    .init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE)
+                    .into()
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Self> {
+                ::core::result::Result::Ok(
+                    builder
+                        .get_struct(
+                            <Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE,
+                            default,
+                        )?
+                        .into(),
+                )
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder(
+                mut pointer: ::capnp::private::layout::PointerBuilder<'_>,
+                value: Self,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                self.builder.into_reader().into()
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder {
+                    builder: self.builder.reborrow(),
+                }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                self.builder.as_reader().into()
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.as_reader().total_size()
+            }
+            #[inline]
+            pub fn get_deals(
+                self,
+            ) -> ::capnp::Result<
+                ::capnp::struct_list::Builder<
+                    'a,
+                    crate::schema::definitions_capnp::deal_info::Owned,
+                >,
+            > {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_deals(
+                &mut self,
+                value: ::capnp::struct_list::Reader<
+                    'a,
+                    crate::schema::definitions_capnp::deal_info::Owned,
+                >,
+            ) -> ::capnp::Result<()> {
+                ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.reborrow().get_pointer_field(0),
+                    value,
+                    false,
+                )
+            }
+            #[inline]
+            pub fn init_deals(
+                self,
+                size: u32,
+            ) -> ::capnp::struct_list::Builder<'a, crate::schema::definitions_capnp::deal_info::Owned>
+            {
+                ::capnp::traits::FromPointerBuilder::init_pointer(
+                    self.builder.get_pointer_field(0),
+                    size,
+                )
+            }
+            #[inline]
+            pub fn has_deals(&self) -> bool {
+                !self.builder.is_pointer_field_null(0)
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+                Self {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            pub static ENCODED_NODE: [::capnp::Word; 39] = [
+                ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+                ::capnp::word(184, 22, 83, 45, 211, 54, 218, 231),
+                ::capnp::word(35, 0, 0, 0, 1, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(21, 0, 0, 0, 186, 1, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(37, 0, 0, 0, 63, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(115, 99, 104, 101, 109, 97, 47, 112),
+                ::capnp::word(114, 111, 118, 105, 100, 101, 114, 46),
+                ::capnp::word(99, 97, 112, 110, 112, 58, 80, 117),
+                ::capnp::word(98, 108, 105, 99, 97, 116, 105, 111),
+                ::capnp::word(110, 115, 46, 108, 97, 116, 101, 115),
+                ::capnp::word(116, 68, 101, 97, 108, 115, 36, 82),
+                ::capnp::word(101, 115, 117, 108, 116, 115, 0, 0),
+                ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(13, 0, 0, 0, 50, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(36, 0, 0, 0, 2, 0, 1, 0),
+                ::capnp::word(100, 101, 97, 108, 115, 0, 0, 0),
+                ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
+                ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(134, 40, 187, 117, 196, 247, 155, 198),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+                ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+            ];
+            pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+                match index {
+                    0 => <::capnp::struct_list::Owned<
+                        crate::schema::definitions_capnp::deal_info::Owned,
+                    > as ::capnp::introspect::Introspect>::introspect(),
+                    _ => panic!("invalid field index {}", index),
+                }
+            }
+            pub fn get_annotation_types(
+                child_index: Option<u16>,
+                index: u32,
+            ) -> ::capnp::introspect::Type {
+                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            }
+            pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
+                ::capnp::introspect::RawStructSchema {
+                    encoded_node: &ENCODED_NODE,
+                    nonunion_members: NONUNION_MEMBERS,
+                    members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+                };
+            pub static NONUNION_MEMBERS: &[u16] = &[0];
+            pub static MEMBERS_BY_DISCRIMINANT: &[u16] = &[];
+            pub const TYPE_ID: u64 = 0xe7da_36d3_2d53_16b8;
+        }
+    }
 }

--- a/lib/worker/.sqlx/query-a748e1a9d24232a405100214f3b71e8bbd4cab31ec5aae99fbd1faf911a77e07.json
+++ b/lib/worker/.sqlx/query-a748e1a9d24232a405100214f3b71e8bbd4cab31ec5aae99fbd1faf911a77e07.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO jobs (ns_id, cid, relation, activated) SELECT id, $2, $3, $4 FROM namespaces WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bytea",
+        "Text",
+        "Timestamp"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a748e1a9d24232a405100214f3b71e8bbd4cab31ec5aae99fbd1faf911a77e07"
+}

--- a/lib/worker/Cargo.toml
+++ b/lib/worker/Cargo.toml
@@ -28,9 +28,12 @@ google-cloud-default = { workspace = true }
 google-cloud-storage = { workspace = true }
 hex = { workspace = true }
 log = { workspace = true }
+multibase = "0.9"
 once_cell = { workspace = true }
 openssl = { workspace = true }
+reqwest = { version = "0.11", features = ["stream"] }
 secp256k1 = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 stderrlog = { workspace = true }
@@ -42,6 +45,7 @@ warp = { workspace = true }
 
 [dev-dependencies]
 basin_exporter = { path = "../exporter" }
+wiremock = "0.5"
 
 [target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.jemallocator]
 version = "0.5.4"

--- a/lib/worker/migrations/20231101162419_timestamp.sql
+++ b/lib/worker/migrations/20231101162419_timestamp.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+ALTER TABLE jobs ADD COLUMN timestamp BIGINT;

--- a/lib/worker/src/db.rs
+++ b/lib/worker/src/db.rs
@@ -1,6 +1,6 @@
 mod publications;
 
 pub use publications::{
-    is_namespace_owner, namespace_create, namespace_exists, pub_cids, pub_jobs_insert,
-    pub_table_create, pub_table_insert,
+    is_namespace_owner, namespace_create, namespace_exists, pub_cids, pub_table_create,
+    pub_table_insert,
 };

--- a/lib/worker/src/db.rs
+++ b/lib/worker/src/db.rs
@@ -1,5 +1,6 @@
 mod publications;
 
 pub use publications::{
-    is_namespace_owner, namespace_create, namespace_exists, pub_table_create, pub_table_insert,
+    is_namespace_owner, namespace_create, namespace_exists, pub_cids, pub_jobs_insert,
+    pub_table_create, pub_table_insert,
 };

--- a/lib/worker/src/db/publications.rs
+++ b/lib/worker/src/db/publications.rs
@@ -89,27 +89,6 @@ pub async fn pub_cids(
     Ok(cids)
 }
 
-// Insert a job (used for testing)
-pub async fn pub_jobs_insert(
-    pool: &PgPool,
-    ns: &str,
-    rel: &str,
-    cid: Vec<u8>,
-    activated: chrono::NaiveDateTime,
-) -> Result<()> {
-    sqlx::query!(
-        "INSERT INTO jobs (ns_id, cid, relation, activated) SELECT id, $2, $3, $4 FROM namespaces WHERE name = $1",
-        ns,
-        cid,
-        rel,
-        activated,
-    )
-    .execute(pool)
-    .await?;
-
-    Ok(())
-}
-
 /// Runs sqlx query within a database transaction.
 async fn txn_execute(
     txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,

--- a/lib/worker/src/db/publications.rs
+++ b/lib/worker/src/db/publications.rs
@@ -1,5 +1,6 @@
 use basin_common::errors::Result;
 use ethers::types::Address;
+use multibase::Base;
 use sqlx::postgres::{PgPool, PgQueryResult};
 use sqlx::Row;
 
@@ -55,6 +56,58 @@ pub async fn pub_table_insert(pool: &PgPool, stmts: Vec<String>) -> Result<()> {
         txn_execute(&mut txn, &s).await?;
     }
     Ok(txn.commit().await?)
+}
+
+// Lists cids of a given publication
+pub async fn pub_cids(
+    pool: &PgPool,
+    ns: String,
+    rel: String,
+    limit: i32,
+    offset: i32,
+) -> Result<Vec<String>> {
+    let res = sqlx::query(
+        "SELECT cid FROM jobs 
+                                                JOIN namespaces ON namespaces.id = jobs.ns_id 
+                                                WHERE name=$1 AND relation = $2
+                                                ORDER BY jobs.id DESC
+                                                LIMIT $3
+                                                OFFSET $4",
+    )
+    .bind(ns)
+    .bind(rel)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await?;
+
+    let cids = res
+        .iter()
+        .map(|row| multibase::encode::<Vec<u8>>(Base::Base32Lower, row.get("cid")))
+        .collect();
+
+    Ok(cids)
+}
+
+// Insert a job (used for testing)
+pub async fn pub_jobs_insert(
+    pool: &PgPool,
+    ns: &str,
+    rel: &str,
+    cid: Vec<u8>,
+    activated: chrono::NaiveDateTime,
+) -> Result<()> {
+    sqlx::query!(
+        "INSERT INTO jobs (ns_id, cid, relation, activated) SELECT id, $2, $3, $4 FROM namespaces WHERE name = $1",
+        ns,
+        cid,
+        rel,
+        activated,
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
 }
 
 /// Runs sqlx query within a database transaction.

--- a/lib/worker/src/lib.rs
+++ b/lib/worker/src/lib.rs
@@ -4,3 +4,4 @@ pub mod gcs;
 pub mod rpc;
 pub mod sql;
 pub mod utils;
+pub mod web3storage;

--- a/lib/worker/src/rpc.rs
+++ b/lib/worker/src/rpc.rs
@@ -248,7 +248,7 @@ impl<E: EVMClient + 'static> publications::Server for Publications<E> {
                 builder.set_cid(status.cid.as_str().into());
                 builder.set_created(status.created.as_str().into());
                 builder.set_size(status.dag_size);
-                builder.set_is_permament(!status.deals.is_empty());
+                builder.set_archived(!status.deals.is_empty());
             }
 
             Ok(())
@@ -302,7 +302,7 @@ impl<E: EVMClient + 'static> publications::Server for Publications<E> {
                 builder.set_cid(status.cid.as_str().into());
                 builder.set_created(status.created.as_str().into());
                 builder.set_size(status.dag_size);
-                builder.set_is_permament(!status.deals.is_empty());
+                builder.set_archived(!status.deals.is_empty());
             }
 
             Ok(())

--- a/lib/worker/src/rpc.rs
+++ b/lib/worker/src/rpc.rs
@@ -1,4 +1,4 @@
-use crate::{crypto, db, gcs::GcsClient, sql, utils};
+use crate::{crypto, db, gcs::GcsClient, sql, utils, web3storage::Web3StorageClient};
 use basin_evm::EVMClient;
 use basin_protocol::publications;
 use capnp::{capability::Promise, Error};
@@ -18,14 +18,21 @@ pub struct Publications<E: EVMClient + 'static> {
     evm_client: E,
     pg_pool: PgPool,
     gcs_client: GcsClient,
+    web3storage_client: Web3StorageClient,
 }
 
 impl<E: EVMClient + 'static> Publications<E> {
-    pub fn new(evm_client: E, pg_pool: PgPool, gcs_client: GcsClient) -> Self {
+    pub fn new(
+        evm_client: E,
+        pg_pool: PgPool,
+        gcs_client: GcsClient,
+        web3storage_client: Web3StorageClient,
+    ) -> Self {
         Self {
             evm_client,
             pg_pool,
             gcs_client,
+            web3storage_client,
         }
     }
 }
@@ -207,21 +214,27 @@ impl<E: EVMClient + 'static> publications::Server for Publications<E> {
         if rel.is_empty() {
             return Promise::err(Error::failed("relation is required".into()));
         }
-        let limit = args.get_limit();
-        let offset = args.get_offset();
+        let limit = args.get_limit() as i32;
+        let offset = args.get_offset() as i32;
 
-        let e = self.evm_client.clone();
+        let pg_pool = self.pg_pool.clone();
+        let web3storage_client = self.web3storage_client.clone();
         Promise::from_future(async move {
-            let deals = e
-                .deals(format!("{}.{}", ns, rel).as_str(), offset, limit)
-                .await?;
+            let cids = db::pub_cids(&pg_pool, ns, rel, limit, offset).await?;
 
-            let mut deals_list = results.get().init_deals(deals.len() as u32);
-            for (i, d) in deals.iter().enumerate() {
+            let mut deals_list = results.get().init_deals(cids.len() as u32);
+            for (i, cid) in cids.iter().enumerate() {
                 let mut builder = deals_list.reborrow().get(i as u32);
-                builder.set_id(d.id);
-                builder.set_cid(d.cid.as_str().into());
-                builder.set_selector_path(d.selector_path.as_str().into());
+
+                let status = web3storage_client
+                    .status_of_cid(cid)
+                    .await
+                    .map_err(|e| Error::failed(e.to_string()))?;
+
+                builder.set_cid(cid.as_str().into());
+                builder.set_created(status.created.as_str().into());
+                builder.set_size(status.dag_size);
+                builder.set_is_permament(!status.deals.is_empty());
             }
 
             Ok(())
@@ -242,24 +255,26 @@ impl<E: EVMClient + 'static> publications::Server for Publications<E> {
         if rel.is_empty() {
             return Promise::err(Error::failed("relation is required".into()));
         }
-        let n = args.get_n();
+        let n = args.get_n() as i32;
 
-        let e = self.evm_client.clone();
+        let pg_pool = self.pg_pool.clone();
+        let web3storage_client = self.web3storage_client.clone();
         Promise::from_future(async move {
-            let deals = e
-                .latest_deals(format!("{}.{}", ns, rel).as_str(), n)
-                .await?;
+            let cids = db::pub_cids(&pg_pool, ns, rel, n, 0).await?;
 
-            let mut deals_list = results.get().init_deals(deals.len() as u32);
-            for (i, d) in deals.iter().enumerate() {
-                let mut di = deals_list.reborrow().get(i as u32);
-                di.set_id(d.id);
+            let mut deals_list = results.get().init_deals(cids.len() as u32);
+            for (i, cid) in cids.iter().enumerate() {
+                let mut builder = deals_list.reborrow().get(i as u32);
 
-                let cid: &str = d.cid.as_str();
-                di.set_cid(cid.into());
+                let status = web3storage_client
+                    .status_of_cid(cid)
+                    .await
+                    .map_err(|e| Error::failed(e.to_string()))?;
 
-                let sp: &str = d.selector_path.as_str();
-                di.set_selector_path(sp.into());
+                builder.set_cid(cid.as_str().into());
+                builder.set_created(status.created.as_str().into());
+                builder.set_size(status.dag_size);
+                builder.set_is_permament(!status.deals.is_empty());
             }
 
             Ok(())
@@ -351,12 +366,15 @@ pub async fn listen<E: EVMClient + 'static>(
     evm_client: E,
     pg_pool: PgPool,
     gcs_client: GcsClient,
+    web3storage_client: Web3StorageClient,
     tcp_listener: TcpListener,
 ) -> Result<(), Box<dyn std::error::Error>> {
     tokio::task::LocalSet::new()
         .run_until(async move {
-            let pubs_handler = Publications::new(evm_client, pg_pool, gcs_client);
+            let pubs_handler =
+                Publications::new(evm_client, pg_pool, gcs_client, web3storage_client);
             let pubs_client: publications::Client = capnp_rpc::new_client(pubs_handler);
+
             info!("RPC API started");
             loop {
                 let (stream, _) = tcp_listener.accept().await?;

--- a/lib/worker/src/web3storage.rs
+++ b/lib/worker/src/web3storage.rs
@@ -1,0 +1,151 @@
+use reqwest::Client;
+use serde::Deserialize;
+use thiserror::Error;
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+pub struct Status {
+    pub created: String,
+    pub cid: String,
+    #[serde(rename = "dagSize")]
+    pub dag_size: u32,
+    pins: Vec<Pin>,
+    pub deals: Vec<Deal>,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+pub struct Pin {
+    status: String,
+    updated: String,
+    #[serde(rename = "peerId")]
+    peer_id: String,
+    #[serde(rename = "peerName")]
+    peer_name: String,
+    region: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+pub struct Deal {
+    #[serde(rename = "dealId")]
+    deal_id: u32,
+    #[serde(rename = "storageProvider")]
+    storage_provider: String,
+    status: String,
+    #[serde(rename = "pieceCid")]
+    piece_cid: String,
+    #[serde(rename = "dataCid")]
+    data_cid: String,
+    #[serde(rename = "dataModelSelector")]
+    data_model_selector: String,
+    activation: String,
+    expiration: String,
+    created: String,
+    updated: String,
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Reqwest error: {0:?}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("Serde JSON parsing error. Response: {1}")]
+    SerdeJSONError(#[source] serde_json::Error, String),
+}
+
+pub const DEFAULT_BASE_URL: &str = "https://api.web3.storage";
+
+#[derive(Clone)]
+pub struct Web3StorageClient {
+    base_url: String,
+}
+
+impl Web3StorageClient {
+    pub fn new(base_url: String) -> Self {
+        Self { base_url }
+    }
+
+    pub async fn status_of_cid(&self, cid: &str) -> Result<Status, Error> {
+        let result = Client::new()
+            .get(format!("{}/status/{}", self.base_url, cid))
+            .header("accept", "application/json")
+            .send()
+            .await?
+            .text()
+            .await?;
+
+        let status: Status =
+            serde_json::from_str(&result).map_err(|e| Error::SerdeJSONError(e, result))?;
+
+        Ok(status)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::web3storage::Web3StorageClient;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn status_of_cid() {
+        let mock_server = MockServer::start().await;
+
+        let web3storage_client = Web3StorageClient::new(mock_server.uri());
+
+        let status_response = r#"{"cid":"bafybeibw2zctx4ca3udcfcsizjmo57bomhb6vvzf63rvc25d6hzotncn2i","dagSize":380733,"created":"2023-10-27T20:08:24.015+00:00","pins":[{"status":"Pinned","updated":"2023-10-27T20:08:24.015+00:00","peerId":"bafzbeibhqavlasjc7dvbiopygwncnrtvjd2xmryk5laib7zyjor6kf3avm","peerName":"elastic-ipfs","region":null}],"deals":[{"dealId":60497440,"storageProvider":"f01392893","status":"Active","pieceCid":"baga6ea4seaqmjfxq45gotde77ay7sqljb7gt5gns3vojgwoj3fb3zmqvddkx2py","dataCid":"bafybeibbpkhnm5wdyw2y2zirndu2coa7mw67vg52hzsl3ogae4owajkd4q","dataModelSelector":"Links/4/Hash/Links/54/Hash/Links/0/Hash","activation":"2023-10-31T07:33:00+00:00","expiration":"2025-04-15T07:33:00+00:00","created":"2023-10-31T13:20:03.875131+00:00","updated":"2023-10-31T13:20:03.875131+00:00"}]}"#;
+        let response = ResponseTemplate::new(200).set_body_string(status_response);
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/status/bafybeibw2zctx4ca3udcfcsizjmo57bomhb6vvzf63rvc25d6hzotncn2i",
+            ))
+            .respond_with(response)
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let status = web3storage_client
+            .status_of_cid("bafybeibw2zctx4ca3udcfcsizjmo57bomhb6vvzf63rvc25d6hzotncn2i")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            "bafybeibw2zctx4ca3udcfcsizjmo57bomhb6vvzf63rvc25d6hzotncn2i",
+            status.cid
+        );
+        assert_eq!(380733, status.dag_size);
+        assert_eq!("2023-10-27T20:08:24.015+00:00", status.created);
+
+        // pin
+        assert_eq!("Pinned", status.pins[0].status);
+        assert_eq!("2023-10-27T20:08:24.015+00:00", status.pins[0].updated);
+        assert_eq!(
+            "bafzbeibhqavlasjc7dvbiopygwncnrtvjd2xmryk5laib7zyjor6kf3avm",
+            status.pins[0].peer_id
+        );
+        assert_eq!("elastic-ipfs", status.pins[0].peer_name);
+        assert_eq!(None, status.pins[0].region);
+
+        // deal
+        assert_eq!(60497440, status.deals[0].deal_id);
+        assert_eq!("f01392893", status.deals[0].storage_provider);
+        assert_eq!("Active", status.deals[0].status);
+        assert_eq!(
+            "baga6ea4seaqmjfxq45gotde77ay7sqljb7gt5gns3vojgwoj3fb3zmqvddkx2py",
+            status.deals[0].piece_cid
+        );
+        assert_eq!(
+            "bafybeibbpkhnm5wdyw2y2zirndu2coa7mw67vg52hzsl3ogae4owajkd4q",
+            status.deals[0].data_cid
+        );
+        assert_eq!(
+            "Links/4/Hash/Links/54/Hash/Links/0/Hash",
+            status.deals[0].data_model_selector
+        );
+        assert_eq!("2023-10-31T07:33:00+00:00", status.deals[0].activation);
+        assert_eq!("2025-04-15T07:33:00+00:00", status.deals[0].expiration);
+        assert_eq!("2023-10-31T13:20:03.875131+00:00", status.deals[0].created);
+        assert_eq!("2023-10-31T13:20:03.875131+00:00", status.deals[0].updated);
+    }
+}

--- a/lib/worker/src/web3storage.rs
+++ b/lib/worker/src/web3storage.rs
@@ -29,9 +29,9 @@ pub struct Pin {
 #[derive(Deserialize, Debug)]
 pub struct Deal {
     #[serde(rename = "dealId")]
-    deal_id: u32,
+    deal_id: Option<u32>,
     #[serde(rename = "storageProvider")]
-    storage_provider: String,
+    storage_provider: Option<String>,
     status: String,
     #[serde(rename = "pieceCid")]
     piece_cid: String,
@@ -39,10 +39,10 @@ pub struct Deal {
     data_cid: String,
     #[serde(rename = "dataModelSelector")]
     data_model_selector: String,
-    activation: String,
-    expiration: String,
-    created: String,
-    updated: String,
+    activation: Option<String>,
+    expiration: Option<String>,
+    created: Option<String>,
+    updated: Option<String>,
 }
 
 #[derive(Error, Debug)]
@@ -128,8 +128,11 @@ mod tests {
         assert_eq!(None, status.pins[0].region);
 
         // deal
-        assert_eq!(60497440, status.deals[0].deal_id);
-        assert_eq!("f01392893", status.deals[0].storage_provider);
+        assert_eq!(Some(60497440), status.deals[0].deal_id);
+        assert_eq!(
+            Some("f01392893".to_string()),
+            status.deals[0].storage_provider
+        );
         assert_eq!("Active", status.deals[0].status);
         assert_eq!(
             "baga6ea4seaqmjfxq45gotde77ay7sqljb7gt5gns3vojgwoj3fb3zmqvddkx2py",
@@ -143,9 +146,21 @@ mod tests {
             "Links/4/Hash/Links/54/Hash/Links/0/Hash",
             status.deals[0].data_model_selector
         );
-        assert_eq!("2023-10-31T07:33:00+00:00", status.deals[0].activation);
-        assert_eq!("2025-04-15T07:33:00+00:00", status.deals[0].expiration);
-        assert_eq!("2023-10-31T13:20:03.875131+00:00", status.deals[0].created);
-        assert_eq!("2023-10-31T13:20:03.875131+00:00", status.deals[0].updated);
+        assert_eq!(
+            Some("2023-10-31T07:33:00+00:00".to_string()),
+            status.deals[0].activation
+        );
+        assert_eq!(
+            Some("2025-04-15T07:33:00+00:00".to_string()),
+            status.deals[0].expiration
+        );
+        assert_eq!(
+            Some("2023-10-31T13:20:03.875131+00:00".to_string()),
+            status.deals[0].created
+        );
+        assert_eq!(
+            Some("2023-10-31T13:20:03.875131+00:00".to_string()),
+            status.deals[0].updated
+        );
     }
 }

--- a/lib/worker/tests/integration.rs
+++ b/lib/worker/tests/integration.rs
@@ -170,7 +170,7 @@ async fn create_publication_and_list_works() {
                 "2023-10-27T20:08:24.015+00:00",
                 deals.get(0).get_created().unwrap()
             );
-            assert!(deals.get(0).get_is_permament());
+            assert!(deals.get(0).get_archived());
             assert_eq!(380733, deals.get(0).get_size());
 
             db::drop(pool.clone(), &db_url).await.unwrap();


### PR DESCRIPTION
# Summary

Changes the deals RPC calls to fetch CIDs from local database and enhances that with web3 storage status data. This change is the first version of the Hot Layer. The local database + web3storage are acting as the Hot Layer. 

This PR goes together with https://github.com/tablelandnetwork/basin-cli/pull/13

# Details
see: https://www.notion.so/textile/Textile-Network-Spec-of-the-PR-hot-layer-implementation-fcfce53cda774b968283f3a95dccbf67?d=dc1a38f87bdf41118b4d6c216170f720