### PR TITLE
allow to pass the filename in write api

### DIFF
--- a/k8s/issuer-lets-encrypt-production.yaml
+++ b/k8s/issuer-lets-encrypt-production.yaml
@@ -17,3 +17,4 @@ spec:
    - http01:
        ingress:
         class: nginx
+        name: ingress-nginx

--- a/lib/worker/src/domain/cache_path.rs
+++ b/lib/worker/src/domain/cache_path.rs
@@ -5,6 +5,10 @@ impl CachePath {
     pub fn from(s: String) -> CachePath {
         CachePath(s)
     }
+
+    pub fn filename(&self) -> Option<String> {
+        self.0.split('/').last().map(|x| x.to_string())
+    }
 }
 
 impl AsRef<str> for CachePath {

--- a/lib/worker/src/routes/vaults.rs
+++ b/lib/worker/src/routes/vaults.rs
@@ -74,17 +74,20 @@ pub async fn find_event_by_id(
         }
     };
 
-    if cache_path.is_none() {
-        let empty: Vec<u8> = Vec::new();
-        return Ok(Box::new(with_status(json(&empty), StatusCode::NOT_FOUND)));
-    }
+    let cache_path = match cache_path {
+        Some(path) => path,
+        None => {
+            let empty: Vec<u8> = Vec::new();
+            return Ok(Box::new(with_status(json(&empty), StatusCode::NOT_FOUND)));
+        }
+    };
 
     let stream = match gcs_client
         .inner
         .download_streamed_object(
             &GetObjectRequest {
                 bucket: gcs_client.bucket.to_string(),
-                object: cache_path.clone().unwrap().as_ref().to_string(),
+                object: cache_path.clone().as_ref().to_string(),
                 ..Default::default()
             },
             &Range::default(),
@@ -110,7 +113,7 @@ pub async fn find_event_by_id(
         "content-disposition",
         format!(
             "attachment; filename=\"{}\"",
-            cache_path.unwrap().filename().unwrap()
+            cache_path.filename().unwrap()
         ),
     );
 

--- a/lib/worker/src/startup.rs
+++ b/lib/worker/src/startup.rs
@@ -89,6 +89,7 @@ mod api {
         warp::path!("vaults" / String / "events")
             .and(warp::post())
             .and(warp::header::<u64>("content-length"))
+            .and(warp::header::<String>("filename"))
             .and(with_gcs_client(gcs_client))
             .and(with_w3s_client(w3s_client))
             .and(with_db(db))

--- a/lib/worker/tests/api/helpers.rs
+++ b/lib/worker/tests/api/helpers.rs
@@ -240,6 +240,7 @@ impl TestApp {
                 timestamp,
                 hex::encode(sigb)
             ))
+            .header("filename", "sample.bin")
             .body(event_content.to_vec())
             .send()
             .await


### PR DESCRIPTION
This PR allows the client to pass the filename as metadata when writing an event. That filename is stored and is retrieved back on retrieval. 

See https://github.com/tablelandnetwork/basin-cli/pulls and https://discord.com/channels/592843512312102924/1163587748784001065/1196923564729839748