### PR TITLE
fixes cid generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "jemallocator",
  "log",
  "multibase",
+ "multihash 0.19.1",
  "once_cell",
  "openssl",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ hyper = { version = "0.14", features = [
 jemallocator = "0.5.4"
 log = "0.4.1"
 multibase = "0.9"
+multihash = "0.19.1"
 once_cell = "1.18.0"
 openssl = { version = "0.10.57", features = ["vendored"] }
 regex = "1.10.2"

--- a/lib/worker/Cargo.toml
+++ b/lib/worker/Cargo.toml
@@ -34,6 +34,7 @@ hex = { workspace = true }
 hyper = { workspace = true }
 log = { workspace = true }
 multibase = { workspace = true }
+multihash = { workspace = true }
 once_cell = { workspace = true }
 openssl = { workspace = true }
 regex = { workspace = true }

--- a/lib/worker/src/routes/vaults.rs
+++ b/lib/worker/src/routes/vaults.rs
@@ -700,8 +700,11 @@ async fn upload_w3s_mock(
     let mut output = [0u8; 32];
     hasher.finalize(&mut output);
 
-    let digest = Multihash::<64>::wrap(0x12, &output).unwrap();
-    let cid = RustCid::new_v1(0x70, digest);
+    const SHA2_256: u64 = 0x12;
+    let digest = Multihash::<64>::wrap(SHA2_256, &output).unwrap();
+
+    const DAG_PB: u64 = 0x70;
+    let cid = RustCid::new_v1(DAG_PB, digest);
     log::info!("uploaded file: {:?}", cid);
 
     Ok(cid.to_bytes())

--- a/lib/worker/tests/api/helpers.rs
+++ b/lib/worker/tests/api/helpers.rs
@@ -215,11 +215,11 @@ impl TestApp {
         &self,
         vault: &str,
         timestamp: i64,
-        event_content: [u8; 256],
+        event_content: Vec<u8>,
     ) -> Response {
         // calculating hash
         let mut hasher = Keccak::v256();
-        hasher.update(&event_content[..256]);
+        hasher.update(&event_content[..]);
         let mut output = [0u8; 32];
         hasher.finalize(&mut output);
 

--- a/lib/worker/tests/api/http.rs
+++ b/lib/worker/tests/api/http.rs
@@ -1,7 +1,7 @@
 use crate::helpers::spawn_app;
 use basin_evm::EVMClient;
 use ethers::{
-    core::rand::{thread_rng, Rng},
+    core::rand::{distributions::Uniform, thread_rng, Rng},
     signers::Signer,
 };
 
@@ -229,8 +229,8 @@ async fn write_event() {
     app.create_vault_with_cache("api.test", 10).await;
 
     // creating random event
-    let mut event_content = [0u8; 256];
-    thread_rng().fill(&mut event_content);
+    let range = Uniform::from(0..20);
+    let event_content = thread_rng().sample_iter(&range).take(100).collect();
 
     let response = app
         .upload_event("api.test", 1701372646, event_content)


### PR DESCRIPTION
This PR changes the CID generation to rely on the hash of the uploaded file and not on the CAR file. 

Building a CAR file and trying to get the CID of that was causing problems. We don't need a CAR file in the current version because we're not uploading to Filecoin. 