### PR TITLE
adds a new version to the /vaults endpoint to list cache duration

### DIFF
--- a/lib/worker/src/db.rs
+++ b/lib/worker/src/db.rs
@@ -1,6 +1,6 @@
 mod publications;
 
 pub use publications::{
-    create_job, delete_expired_job, find_job_cache_path_by_cid, get_cache_config,
-    is_namespace_owner, namespace_create, namespace_exists, pub_cids,
+    create_job, delete_expired_job, find_cache_config_by_vaults, find_job_cache_path_by_cid,
+    get_cache_config, is_namespace_owner, namespace_create, namespace_exists, pub_cids,
 };

--- a/lib/worker/src/db/publications.rs
+++ b/lib/worker/src/db/publications.rs
@@ -83,7 +83,7 @@ pub async fn get_cache_config(pool: &PgPool, vault: &Vault) -> Result<Option<i64
 
 pub async fn find_cache_config_by_vaults(
     pool: &PgPool,
-    vaults: Vec<Vault>,
+    vaults: &Vec<Vault>,
 ) -> Result<Vec<(String, Option<i64>)>> {
     let where_clause = (1..2 * vaults.len() + 1)
         .step_by(2)

--- a/lib/worker/src/domain/vault.rs
+++ b/lib/worker/src/domain/vault.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Vault {
     ns: String,
     rel: String,

--- a/lib/worker/src/domain/vault.rs
+++ b/lib/worker/src/domain/vault.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use std::fmt;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Vault {
     ns: String,
     rel: String,

--- a/lib/worker/src/routes/vaults.rs
+++ b/lib/worker/src/routes/vaults.rs
@@ -190,7 +190,7 @@ pub async fn find_vaults_by_account_v2<E: EVMClient + 'static + std::marker::Syn
     }
 
     let mut response: Vec<ResponseItem> = Vec::new();
-    let rows = match db::find_cache_config_by_vaults(&pool, vaults.clone()).await {
+    let rows = match db::find_cache_config_by_vaults(&pool, &vaults).await {
         Ok(v) => v,
         Err(err) => {
             log::error!("{}", err);

--- a/lib/worker/src/startup.rs
+++ b/lib/worker/src/startup.rs
@@ -39,6 +39,7 @@ mod api {
     ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         health()
             .or(vaults_list(evm_client.clone()))
+            .or(vaults_list_v2(evm_client.clone(), db.clone()))
             .or(vaults_create(evm_client, db.clone()))
             .or(vaults_events_create(
                 db.clone(),
@@ -65,6 +66,19 @@ mod api {
             .and(with_evm_client(evm_client))
             .and(warp::query::<FindVaultsByAccountParams>())
             .and_then(routes::find_vaults_by_account)
+    }
+
+    // GET /v2/vaults
+    pub fn vaults_list_v2<E: EVMClient + 'static + std::marker::Sync>(
+        evm_client: E,
+        db: PgPool,
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+        warp::path!("v2" / "vaults")
+            .and(warp::get())
+            .and(with_evm_client(evm_client))
+            .and(with_db(db))
+            .and(warp::query::<FindVaultsByAccountParams>())
+            .and_then(routes::find_vaults_by_account_v2)
     }
 
     // POST /vaults/:id

--- a/lib/worker/tests/api/helpers.rs
+++ b/lib/worker/tests/api/helpers.rs
@@ -145,6 +145,18 @@ impl TestApp {
             .expect("Failed to execute request.")
     }
 
+    pub async fn get_vaults_v2(&self) -> Response {
+        self.api_client
+            .get(&format!(
+                "{}/v2/vaults?account={:#x}",
+                &self.address,
+                self.account.address()
+            ))
+            .send()
+            .await
+            .expect("Failed to execute request.")
+    }
+
     pub async fn get_events_from_vaults(&self, vault: &str) -> Response {
         self.api_client
             .get(&format!("{}/vaults/{}/events", &self.address, vault))

--- a/lib/worker/tests/api/http.rs
+++ b/lib/worker/tests/api/http.rs
@@ -38,6 +38,37 @@ async fn list_vaults() {
 }
 
 #[tokio::test]
+async fn list_vaults_v2() {
+    let app = spawn_app().await;
+
+    // setup
+    app.create_vault("api.test").await;
+    app.create_vault_with_cache("api.test2", 100).await;
+
+    // make request
+    let response = app
+        .get_vaults_v2()
+        .await
+        .text()
+        .await
+        .unwrap()
+        .parse::<serde_json::Value>()
+        .unwrap();
+    assert_eq!(
+        json!([
+        {
+            "vault": "api.test",
+            "cache_duration": null,
+        },
+        {
+            "vault": "api.test2",
+            "cache_duration": 100,
+        }]),
+        response
+    );
+}
+
+#[tokio::test]
 async fn list_events() {
     let app = spawn_app().await;
 


### PR DESCRIPTION
# Summary

This PR adds a `/v2/vault` endpoint that lists the vaults from a given account and the cache duration of that vault.
We needed to add a version because the response is a breaking change.

Here's a response sample:

```json
[
  {
    "vault": "api50.test",
    "cache_duration": null
  },
  {
    "vault": "api51.test",
    "cache_duration": 10
  }
]
```
Goes together with https://github.com/tablelandnetwork/basin-cli/pull/41 and closes [ENG-761](https://linear.app/tableland/issue/ENG-761/add-the-cache-value-as-part-of-the-data-being-listed)